### PR TITLE
make const_reference types that are actually value_types not be const

### DIFF
--- a/include/sdsl/int_vector.hpp
+++ b/include/sdsl/int_vector.hpp
@@ -99,7 +99,7 @@ struct int_vector_trait {
 	typedef uint64_t								   value_type;
 	typedef int_vector<t_width>						   int_vector_type;
 	typedef int_vector_reference<int_vector_type>	  reference;
-	typedef const uint64_t							   const_reference;
+	typedef uint64_t							   const_reference;
 	typedef uint8_t									   int_width_type;
 	typedef int_vector_iterator<int_vector_type>	   iterator;
 	typedef int_vector_const_iterator<int_vector_type> const_iterator;
@@ -134,7 +134,7 @@ struct int_vector_trait<64> {
 	typedef uint64_t		value_type;
 	typedef int_vector<64>  int_vector_type;
 	typedef uint64_t&		reference;
-	typedef const uint64_t  const_reference;
+	typedef uint64_t  const_reference;
 	typedef uint8_t			int_width_type;
 	typedef uint64_t*		iterator;
 	typedef const uint64_t* const_iterator;
@@ -159,7 +159,7 @@ struct int_vector_trait<32> {
 	typedef uint32_t		value_type;
 	typedef int_vector<32>  int_vector_type;
 	typedef uint32_t&		reference;
-	typedef const uint32_t  const_reference;
+	typedef uint32_t  const_reference;
 	typedef uint8_t			int_width_type;
 	typedef uint32_t*		iterator;
 	typedef const uint32_t* const_iterator;
@@ -187,7 +187,7 @@ struct int_vector_trait<16> {
 	typedef uint16_t		value_type;
 	typedef int_vector<16>  int_vector_type;
 	typedef uint16_t&		reference;
-	typedef const uint16_t  const_reference;
+	typedef uint16_t  const_reference;
 	typedef uint8_t			int_width_type;
 	typedef uint16_t*		iterator;
 	typedef const uint16_t* const_iterator;
@@ -215,7 +215,7 @@ struct int_vector_trait<8> {
 	typedef uint8_t		   value_type;
 	typedef int_vector<8>  int_vector_type;
 	typedef uint8_t&	   reference;
-	typedef const uint8_t  const_reference;
+	typedef uint8_t  const_reference;
 	typedef uint8_t		   int_width_type;
 	typedef uint8_t*	   iterator;
 	typedef const uint8_t* const_iterator;


### PR DESCRIPTION
In those cases where where the `const_reference` type actually generates instead of a returning a reference it doesn't make sense to add `const` to the type (because a temporary object is returned anyway). In fact, the `const` has no effect, but GCC warns about this when you set `-Wignored-qualifiers` or `-Wall -Wextra` which is great to have for libraries to ensure minimal problems for downstream.