### PR TITLE
Add missing != and == operators to bitvectors

### DIFF
--- a/include/sdsl/dac_vector.hpp
+++ b/include/sdsl/dac_vector.hpp
@@ -159,6 +159,16 @@ public:
 		m_level_pointer_and_rank.load(in);
 		read_member(m_max_level, in);
 	}
+
+
+	bool operator==(const dac_vector& v) const
+	{
+		return m_max_level && v.m_max_level && m_data == v.m_data && m_overflow == v.m_overflow &&
+			   m_overflow_rank == v.m_overflow_rank &&
+			   m_level_pointer_and_rank == v.m_level_pointer_and_rank;
+	}
+
+	bool operator!=(const dac_vector& v) const { return !(*this == v); }
 };
 
 template <uint8_t t_b, typename t_rank>

--- a/include/sdsl/enc_vector.hpp
+++ b/include/sdsl/enc_vector.hpp
@@ -112,6 +112,14 @@ public:
 	//! Iterator that points to the position after the last element of the enc_vector.
 	const const_iterator end() const { return const_iterator(this, this->m_size); }
 
+	bool operator==(const enc_vector& v) const
+	{
+		return m_size && v.m_size && m_z == v.m_z &&
+			   m_sample_vals_and_pointer == v.m_sample_vals_and_pointer;
+	}
+
+	bool operator!=(const enc_vector& v) const { return !(*this == v); }
+
 	//! operator[]
 	/*! \param i Index. \f$ i \in [0..size()-1]\f$.
          */

--- a/include/sdsl/hyb_vector.hpp
+++ b/include/sdsl/hyb_vector.hpp
@@ -571,6 +571,14 @@ public:
 	iterator begin() const { return iterator(this, 0); }
 
 	iterator end() const { return iterator(this, size()); }
+
+	bool operator==(const hyb_vector& v) const
+	{
+		return m_size == v.m_size && m_trunk == v.m_trunk && m_sblock_header == v.m_sblock_header &&
+			   m_hblock_header == v.m_hblock_header;
+	}
+
+	bool operator!=(const hyb_vector& v) const { return !(*this == v); }
 };
 
 template <uint32_t k_sblock_rate>

--- a/include/sdsl/rrr_vector.hpp
+++ b/include/sdsl/rrr_vector.hpp
@@ -93,8 +93,8 @@ private:
 	int_vector<> m_btnrp;  // Sample pointers into m_btnr.
 	int_vector<> m_rank;   // Sample rank values.
 	bit_vector   m_invert; // Specifies if a superblock (i.e. t_k blocks)
-	// have to be considered as inverted i.e. 1 and
-	// 0 are swapped
+						   // have to be considered as inverted i.e. 1 and
+						   // 0 are swapped
 
 public:
 	const rac_type&   bt   = m_bt;
@@ -346,6 +346,14 @@ public:
 	iterator begin() const { return iterator(this, 0); }
 
 	iterator end() const { return iterator(this, size()); }
+
+	bool operator==(const rrr_vector& v) const
+	{
+		return m_size == v.m_size && m_bt == v.m_bt && m_btnr == v.m_btnr && m_btnrp == v.m_btnrp &&
+			   m_rank == v.m_rank && m_invert == v.m_invert;
+	}
+
+	bool operator!=(const rrr_vector& v) const { return !(*this == v); }
 };
 
 template <uint8_t t_bit_pattern>

--- a/include/sdsl/sd_vector.hpp
+++ b/include/sdsl/sd_vector.hpp
@@ -399,6 +399,13 @@ public:
 	iterator begin() const { return iterator(this, 0); }
 
 	iterator end() const { return iterator(this, size()); }
+
+	bool operator==(const sd_vector& v) const
+	{
+		return m_size == v.m_size && m_wl == v.m_wl && m_low == v.m_low && m_high == v.m_high;
+	}
+
+	bool operator!=(const sd_vector& v) const { return !(*this == v); }
 };
 
 //! Specialized constructor that is a bit more space-efficient than the default.

--- a/include/sdsl/vlc_vector.hpp
+++ b/include/sdsl/vlc_vector.hpp
@@ -98,6 +98,14 @@ public:
 	//! Iterator that points to the position after the last element of the vlc_vector.
 	const const_iterator end() const { return const_iterator(this, this->m_size); }
 
+	bool operator==(const vlc_vector& v) const
+	{
+		return m_size && v.m_size && m_z == v.m_z && m_sample_pointer == v.m_sample_pointer;
+	}
+
+	bool operator!=(const vlc_vector& v) const { return !(*this == v); }
+
+
 	//! []-operator
 	value_type operator[](size_type i) const;
 

--- a/test/bit_vector_test.cpp.cmake
+++ b/test/bit_vector_test.cpp.cmake
@@ -3,8 +3,7 @@
 #include "gtest/gtest.h"
 #include <string>
 
-namespace
-{
+namespace {
 
 using namespace sdsl;
 using namespace std;
@@ -13,196 +12,186 @@ string test_file;
 string temp_file;
 string temp_dir;
 
-template<class T>
-class bit_vector_test : public ::testing::Test { };
+template <class T>
+class bit_vector_test : public ::testing::Test {
+};
 
-template<class T>
-class bit_vector_test_bv_only : public ::testing::Test { };
+template <class T>
+class bit_vector_test_bv_only : public ::testing::Test {
+};
 
 using testing::Types;
 
+// clang-format off
 typedef Types<@typedef_line@> Implementations;
+// clang-format on
 
-typedef Types<
-bit_vector
-> Implementations_BV_Only;
+typedef Types<bit_vector> Implementations_BV_Only;
 
 
 TYPED_TEST_CASE(bit_vector_test, Implementations);
 
-TYPED_TEST(bit_vector_test, store_and_load)
+//! Test operator==
+TYPED_TEST(bit_vector_test, equality_operator)
 {
-    static_assert(sdsl::util::is_regular<TypeParam>::value, "Type is not regular");
-    bit_vector bv;
-    ASSERT_TRUE(load_from_file(bv, test_file));
-    TypeParam c_bv(bv);
-    ASSERT_TRUE(store_to_file(c_bv, temp_file));
-    TypeParam cc_bv;
-    ASSERT_TRUE(load_from_file(cc_bv, temp_file));
-    ASSERT_EQ(c_bv.size(), cc_bv.size());
-    for (uint64_t j=0; j+64 < c_bv.size(); j+=64) {
-        ASSERT_EQ(c_bv.get_int(j, 64), cc_bv.get_int(j, 64));
-    }
-    for (uint64_t j = (c_bv.size()/64)/64; j < c_bv.size(); j += 64) {
-        ASSERT_EQ((bool)(bv[j]), (bool)(c_bv[j]));
-    }
+	static_assert(sdsl::util::is_regular<TypeParam>::value, "Type is not regular");
+	bit_vector bv;
+	ASSERT_TRUE(load_from_file(bv, test_file));
+	TypeParam c_bv(bv);
+	ASSERT_TRUE(store_to_file(c_bv, temp_file));
+	TypeParam cc_bv;
+	ASSERT_TRUE(load_from_file(cc_bv, temp_file));
+	ASSERT_EQ(c_bv.size(), cc_bv.size());
+	ASSERT_EQ(c_bv, cc_bv);
 }
 
 //! Test operator[]
 TYPED_TEST(bit_vector_test, access)
 {
-    bit_vector bv;
-    ASSERT_TRUE(load_from_file(bv, test_file));
-    TypeParam c_bv(bv);
-    ASSERT_EQ(bv.size(), c_bv.size());
-    for (uint64_t j=0; j < bv.size(); ++j) {
-        ASSERT_EQ((bool)(bv[j]), (bool)(c_bv[j]));
-    }
-    TypeParam mo_bv = TypeParam(bv);
-    ASSERT_EQ(bv.size(), mo_bv.size());
-    for (uint64_t j=0; j < bv.size(); ++j) {
-        ASSERT_EQ((bool)(bv[j]), (bool)(c_bv[j]));
-    }
+	bit_vector bv;
+	ASSERT_TRUE(load_from_file(bv, test_file));
+	TypeParam c_bv(bv);
+	ASSERT_EQ(bv.size(), c_bv.size());
+	for (uint64_t j = 0; j < bv.size(); ++j) {
+		ASSERT_EQ((bool)(bv[j]), (bool)(c_bv[j]));
+	}
+	TypeParam mo_bv = TypeParam(bv);
+	ASSERT_EQ(bv.size(), mo_bv.size());
+	for (uint64_t j = 0; j < bv.size(); ++j) {
+		ASSERT_EQ((bool)(bv[j]), (bool)(c_bv[j]));
+	}
 }
 
 TYPED_TEST(bit_vector_test, get_int)
 {
-    bit_vector bv;
-    ASSERT_TRUE(load_from_file(bv, test_file));
-    TypeParam c_bv(bv);
-    ASSERT_EQ(bv.size(), c_bv.size());
-    uint8_t len = 63;
-    for (uint64_t j=0; j+len < bv.size(); j+=len) {
-        ASSERT_EQ(bv.get_int(j, len), c_bv.get_int(j, len));
-    }
+	bit_vector bv;
+	ASSERT_TRUE(load_from_file(bv, test_file));
+	TypeParam c_bv(bv);
+	ASSERT_EQ(bv.size(), c_bv.size());
+	uint8_t len = 63;
+	for (uint64_t j = 0; j + len < bv.size(); j += len) {
+		ASSERT_EQ(bv.get_int(j, len), c_bv.get_int(j, len));
+	}
 }
 
 TYPED_TEST(bit_vector_test, get_int_all_block_sizes)
 {
-    bit_vector bv(10000, 0);
-    std::mt19937_64 rng;
-    std::uniform_int_distribution<uint64_t> distribution(0, 9);
-    auto dice = bind(distribution, rng);
-    for (size_t i=1001; i < bv.size(); ++i) {
-        if (0 == dice())
-            bv[i] = 1;
-    }
+	bit_vector								bv(10000, 0);
+	std::mt19937_64							rng;
+	std::uniform_int_distribution<uint64_t> distribution(0, 9);
+	auto									dice = bind(distribution, rng);
+	for (size_t i = 1001; i < bv.size(); ++i) {
+		if (0 == dice()) bv[i] = 1;
+	}
 
-    TypeParam c_bv(bv);
-    for (uint8_t len=1; len<=64; ++len) {
-        for (size_t i=0; i+len <= bv.size(); ++i) {
-            ASSERT_EQ(bv.get_int(i,len), c_bv.get_int(i,len))
-                    << "i="<<i<<" len="<<(int)len<<endl;
-        }
-    }
+	TypeParam c_bv(bv);
+	for (uint8_t len = 1; len <= 64; ++len) {
+		for (size_t i = 0; i + len <= bv.size(); ++i) {
+			ASSERT_EQ(bv.get_int(i, len), c_bv.get_int(i, len)) << "i=" << i << " len=" << (int)len
+																<< endl;
+		}
+	}
 }
 
 TYPED_TEST(bit_vector_test, swap)
 {
-    bit_vector bv;
-    ASSERT_TRUE(load_from_file(bv, test_file));
-    TypeParam c_bv(bv);
-    ASSERT_EQ(bv.size(), c_bv.size());
-    TypeParam bv_empty;
-    ASSERT_EQ((uint64_t)0, bv_empty.size());
-    std::swap(bv_empty,c_bv);
-    ASSERT_EQ((uint64_t)0, c_bv.size());
-    ASSERT_EQ(bv.size(), bv_empty.size());
-    for (uint64_t j=0; j < bv.size(); ++j) {
-        ASSERT_EQ((bool)(bv[j]), (bool)(bv_empty[j]));
-    }
+	bit_vector bv;
+	ASSERT_TRUE(load_from_file(bv, test_file));
+	TypeParam c_bv(bv);
+	ASSERT_EQ(bv.size(), c_bv.size());
+	TypeParam bv_empty;
+	ASSERT_EQ((uint64_t)0, bv_empty.size());
+	std::swap(bv_empty, c_bv);
+	ASSERT_EQ((uint64_t)0, c_bv.size());
+	ASSERT_EQ(bv.size(), bv_empty.size());
+	for (uint64_t j = 0; j < bv.size(); ++j) {
+		ASSERT_EQ((bool)(bv[j]), (bool)(bv_empty[j]));
+	}
 }
 
-TYPED_TEST(bit_vector_test, delete_)
-{
-    sdsl::remove(temp_file);
-}
+TYPED_TEST(bit_vector_test, delete_) { sdsl::remove(temp_file); }
 
 TYPED_TEST_CASE(bit_vector_test_bv_only, Implementations_BV_Only);
 
-#define LFSR_START    0x00000001  // linear-feedback shift register with
-#define LFSR_FEEDBACK 0x0110F65C  // .. period 33554431 = 31*601*1801
-#define LFSR_NEXT(x)  (((x) >> 1) ^ (((x)&1)*LFSR_FEEDBACK))
+#define LFSR_START 0x00000001	// linear-feedback shift register with
+#define LFSR_FEEDBACK 0x0110F65C // .. period 33554431 = 31*601*1801
+#define LFSR_NEXT(x) (((x) >> 1) ^ (((x)&1) * LFSR_FEEDBACK))
 // nota bene: LFSR output has ~50% 1s, will bias compression types like RRR
 
 
 TYPED_TEST(bit_vector_test_bv_only, and_with)
 {
-    bit_vector bv;
-    ASSERT_TRUE(load_from_file(bv, test_file));
-    TypeParam bv1(bv);
+	bit_vector bv;
+	ASSERT_TRUE(load_from_file(bv, test_file));
+	TypeParam bv1(bv);
 
-    TypeParam bv2(bv1.size(), 0);
-    uint32_t lfsr = LFSR_START;
-    for (size_t i=0; i < bv1.size(); ++i) {
-        lfsr = LFSR_NEXT(lfsr);
-        bv2[i] = lfsr&1;
-    }
+	TypeParam bv2(bv1.size(), 0);
+	uint32_t  lfsr = LFSR_START;
+	for (size_t i = 0; i < bv1.size(); ++i) {
+		lfsr   = LFSR_NEXT(lfsr);
+		bv2[i] = lfsr & 1;
+	}
 
-    bv2 &= bv1;
+	bv2 &= bv1;
 
-    lfsr = LFSR_START;
-    for (size_t i=0; i < bv1.size(); ++i) {
-        lfsr = LFSR_NEXT(lfsr);
-        ASSERT_EQ(bv2[i], bv1[i] & (lfsr&1))
-                << "i="<<i<<endl;
-    }
+	lfsr = LFSR_START;
+	for (size_t i = 0; i < bv1.size(); ++i) {
+		lfsr = LFSR_NEXT(lfsr);
+		ASSERT_EQ(bv2[i], bv1[i] & (lfsr & 1)) << "i=" << i << endl;
+	}
 }
 
 TYPED_TEST(bit_vector_test_bv_only, or_with)
 {
-    bit_vector bv;
-    ASSERT_TRUE(load_from_file(bv, test_file));
-    TypeParam bv1(bv);
+	bit_vector bv;
+	ASSERT_TRUE(load_from_file(bv, test_file));
+	TypeParam bv1(bv);
 
-    TypeParam bv2(bv1.size(), 0);
-    uint32_t lfsr = LFSR_START;
-    for (size_t i=0; i < bv1.size(); ++i) {
-        lfsr = LFSR_NEXT(lfsr);
-        bv2[i] = lfsr&1;
-    }
+	TypeParam bv2(bv1.size(), 0);
+	uint32_t  lfsr = LFSR_START;
+	for (size_t i = 0; i < bv1.size(); ++i) {
+		lfsr   = LFSR_NEXT(lfsr);
+		bv2[i] = lfsr & 1;
+	}
 
-    bv2 |= bv1;
+	bv2 |= bv1;
 
-    lfsr = LFSR_START;
-    for (size_t i=0; i < bv1.size(); ++i) {
-        lfsr = LFSR_NEXT(lfsr);
-        ASSERT_EQ(bv2[i], bv1[i] | (lfsr&1))
-                << "i="<<i<<endl;
-    }
+	lfsr = LFSR_START;
+	for (size_t i = 0; i < bv1.size(); ++i) {
+		lfsr = LFSR_NEXT(lfsr);
+		ASSERT_EQ(bv2[i], bv1[i] | (lfsr & 1)) << "i=" << i << endl;
+	}
 }
 
 TYPED_TEST(bit_vector_test_bv_only, xor_with)
 {
-    bit_vector bv;
-    ASSERT_TRUE(load_from_file(bv, test_file));
-    TypeParam bv1(bv);
+	bit_vector bv;
+	ASSERT_TRUE(load_from_file(bv, test_file));
+	TypeParam bv1(bv);
 
-    TypeParam bv2(bv1.size(), 0);
-    uint32_t lfsr = LFSR_START;
-    for (size_t i=0; i < bv1.size(); ++i) {
-        lfsr = LFSR_NEXT(lfsr);
-        bv2[i] = lfsr&1;
-    }
+	TypeParam bv2(bv1.size(), 0);
+	uint32_t  lfsr = LFSR_START;
+	for (size_t i = 0; i < bv1.size(); ++i) {
+		lfsr   = LFSR_NEXT(lfsr);
+		bv2[i] = lfsr & 1;
+	}
 
-    bv2 ^= bv1;
+	bv2 ^= bv1;
 
-    lfsr = LFSR_START;
-    for (size_t i=0; i < bv1.size(); ++i) {
-        lfsr = LFSR_NEXT(lfsr);
-        ASSERT_EQ(bv2[i], bv1[i] ^ (lfsr&1))
-                << "i="<<i<<endl;
-    }
+	lfsr = LFSR_START;
+	for (size_t i = 0; i < bv1.size(); ++i) {
+		lfsr = LFSR_NEXT(lfsr);
+		ASSERT_EQ(bv2[i], bv1[i] ^ (lfsr & 1)) << "i=" << i << endl;
+	}
 }
 
-}// end namespace
+} // end namespace
 
 int main(int argc, char* argv[])
 {
-    ::testing::InitGoogleTest(&argc, argv);
-    if ( init_2_arg_test(argc, argv, "BV", test_file, temp_dir, temp_file) != 0 ) {
-        return 1;
-    }
-    return RUN_ALL_TESTS();
+	::testing::InitGoogleTest(&argc, argv);
+	if (init_2_arg_test(argc, argv, "BV", test_file, temp_dir, temp_file) != 0) {
+		return 1;
+	}
+	return RUN_ALL_TESTS();
 }
-


### PR DESCRIPTION
This adds operators !+ and == to all of the bitvector classes.

I think a template overloaded operator == would also be nice so different bitvector types could be compared easily.