### PR TITLE
remove linking to sdsl library from benchmark Makefiles

### DIFF
--- a/benchmark/indexing_count/Makefile
+++ b/benchmark/indexing_count/Makefile
@@ -1,6 +1,6 @@
 include ../Make.helper
 CFLAGS = $(MY_CXX_FLAGS) # in compile_options.config
-LIBS = -lsdsl -ldivsufsort -ldivsufsort64
+LIBS = -ldivsufsort -ldivsufsort64
 SRC_DIR = src
 TMP_DIR = ../tmp
 PAT_DIR = pattern

--- a/benchmark/indexing_extract/Makefile
+++ b/benchmark/indexing_extract/Makefile
@@ -1,6 +1,6 @@
 include ../Make.helper
 CFLAGS = $(MY_CXX_FLAGS) $(MY_CXX_OPT_FLAGS) 
-LIBS = -lsdsl -ldivsufsort -ldivsufsort64
+LIBS = -ldivsufsort -ldivsufsort64
 SRC_DIR = src
 TMP_DIR = ../tmp
 IVL_DIR = intervals

--- a/benchmark/indexing_locate/Makefile
+++ b/benchmark/indexing_locate/Makefile
@@ -1,6 +1,6 @@
 include ../Make.helper
 CFLAGS = $(MY_CXX_FLAGS) $(MY_CXX_OPT_FLAGS) 
-LIBS = -lsdsl -ldivsufsort -ldivsufsort64
+LIBS = -ldivsufsort -ldivsufsort64
 SRC_DIR = src
 TMP_DIR = ../tmp
 PAT_DIR = pattern

--- a/benchmark/k2_trees/Makefile
+++ b/benchmark/k2_trees/Makefile
@@ -2,7 +2,7 @@ include ../../Make.helper
 CFLAGS = $(MY_CXX_FLAGS)
 SRC_DIR = src
 BIN_DIR = bin
-LIBS = -lsdsl
+LIBS =
 
 C_OPTIONS:=$(call config_ids,compile_options.config)
 TC_IDS:=$(call config_ids,test_case.config)

--- a/benchmark/lcp/Makefile
+++ b/benchmark/lcp/Makefile
@@ -2,7 +2,7 @@ include ../../Make.helper
 CFLAGS = $(MY_CXX_FLAGS) 
 SRC_DIR = src
 BIN_DIR = bin
-LIBS = -lsdsl -ldivsufsort -ldivsufsort64
+LIBS = -ldivsufsort -ldivsufsort64
 
 C_OPTIONS:=$(call config_ids,compile_options.config)
 TC_IDS:=$(call config_ids,test_case.config)

--- a/benchmark/rrr_vector/Makefile
+++ b/benchmark/rrr_vector/Makefile
@@ -1,6 +1,6 @@
 include ../Make.helper
 CXX_FLAGS = $(MY_CXX_FLAGS) # in compile_options.config
-LIBS = -lsdsl 
+LIBS =
 SRC_DIR = src
 TMP_DIR = ../tmp
 # Sampling rate for rrr_vector

--- a/benchmark/self_delimiting_codes/Makefile
+++ b/benchmark/self_delimiting_codes/Makefile
@@ -1,7 +1,7 @@
 include ../../Make.helper
 SRC_DIR = src
 BIN_DIR = bin
-LIBS = -lsdsl
+LIBS =
 RES_FILE = results/result.csv	#result file of benchmark
 VAT_FILE = results/vat.csv	#vector assignment table (vector name -> sdsl type)
 TC_FILE = results/tc.csv	#test case table (contains only test case names)

--- a/benchmark/suffix_trees/Makefile
+++ b/benchmark/suffix_trees/Makefile
@@ -1,5 +1,5 @@
 include ../Make.helper
-LIBS=-lsdsl -ldivsufsort -ldivsufsort64
+LIBS=-ldivsufsort -ldivsufsort64
 SRC_DIR=src
 TMP_DIR=../tmp
 

--- a/benchmark/wavelet_trees/Makefile
+++ b/benchmark/wavelet_trees/Makefile
@@ -2,7 +2,7 @@ include ../../Make.helper
 CFLAGS = $(MY_CXX_FLAGS) 
 SRC_DIR = src
 BIN_DIR = bin
-LIBS = -lsdsl 
+LIBS =
 
 C_OPTIONS:=$(call config_ids,compile_options.config)
 TC_IDS:=$(call config_ids,test_case.config)


### PR DESCRIPTION

sdsl is now a header-only package.  Do not need "-lsdsl" option in Makefiles