### PR TITLE
Mark inline function as such

### DIFF
--- a/include/sdsl/util.hpp
+++ b/include/sdsl/util.hpp
@@ -202,7 +202,7 @@ inline std::string basename(std::string file)
 /*! \param file  Path to a file.
  *  \returns     Directory name part of the specified path.
  */
-std::string dirname(std::string file)
+inline std::string dirname(std::string file)
 {
 	bool ram_file = is_ram_file(file);
 	file		  = disk_file_name(file); // remove RAM-prefix


### PR DESCRIPTION
I got linker errors like this without the modification:
duplicate symbol __ZN4sdsl4util7dirnameENSt3__112basic_stringIcNS1_11char_traitsIcEENS1_9allocatorIcEEEE