### PR TITLE
[FIX] Remove global macro, fix overload resolution

### DIFF
--- a/include/sdsl/cereal.hpp
+++ b/include/sdsl/cereal.hpp
@@ -8,11 +8,6 @@
 #ifndef INCLUDED_SDSL_CEREAL
 #define INCLUDED_SDSL_CEREAL
 
-#define CEREAL_SERIALIZE_FUNCTION_NAME cereal_serialize
-#define CEREAL_LOAD_FUNCTION_NAME cereal_load
-#define CEREAL_SAVE_FUNCTION_NAME cereal_save
-#define CEREAL_LOAD_MINIMAL_FUNCTION_NAME cereal_load_minimal
-#define CEREAL_SAVE_MINIMAL_FUNCTION_NAME cereal_save_minimal
 
 #if defined(__has_include)
 	#if __has_include(<cereal/cereal.hpp>)
@@ -32,6 +27,12 @@
 	#define SDSL_HAS_CEREAL 0
 
 	#define CEREAL_NVP(X) X
+
+	#define CEREAL_SERIALIZE_FUNCTION_NAME serialize
+	#define CEREAL_LOAD_FUNCTION_NAME load
+	#define CEREAL_SAVE_FUNCTION_NAME save
+	#define CEREAL_LOAD_MINIMAL_FUNCTION_NAME load_minimal
+	#define CEREAL_SAVE_MINIMAL_FUNCTION_NAME save_minimal
 
 	namespace cereal
 	{

--- a/include/sdsl/k2_tree.hpp
+++ b/include/sdsl/k2_tree.hpp
@@ -496,7 +496,8 @@ public:
 
 	//!\brief Load via cereal
 	template <typename archive_t>
-	void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
+	typename std::enable_if<cereal::traits::is_output_serializable<k2_tree, archive_t>::value, void>::type
+	CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
 	{
 		ar(CEREAL_NVP(k_k));
 		ar(CEREAL_NVP(k_height));


### PR DESCRIPTION
We can't define the cereal macros if cereal is available (breaks code since the macro gets redefined when including cereal.hpp from the SDSL).

Without the unique names for cereal's serialisation, we need to restrict k2_tree's function to only work on cereal archives since SDSL's `load` and cereal's `load` are equivalent (because they have the same number of template parameters), but cereal's is apparently more specific - this leads to an error in the tests when the SDSL's `load` function is tested.
