### PR TITLE
[INFRA,FEATURE] Header test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,15 @@ matrix:
           sources: ['ubuntu-toolchain-r-test']
           packages: ['cmake', 'g++-7']
 
+    - env:
+        - MYCC="gcc-7" MYCXX="g++-7" MYBUILD=Release
+        - HEADER_TEST="ON"
+      os: linux
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['cmake', 'g++-7']
+
     - env: MYCC="gcc-8" MYCXX="g++-8" MYBUILD=Release
       os: linux
       addons:
@@ -101,11 +110,14 @@ before_script:
 script:
   - cd ${TRAVIS_BUILD_DIR}
   - mkdir sdsl-lite-build && cd sdsl-lite-build
-  - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_BUILD_TYPE=$MYBUILD -DCMAKE_CXX_FLAGS="-Werror -Wno-missing-field-initializers ${CXX_FLAGS}" -DSDSL_CEREAL=$HAS_CEREAL
-  - make sdsl_test_targets -k -j 2
-  - travis_wait 90 sleep infinity & ctest . -j 2 --output-on-failure -E ${CTEST_EXCLUDE} -R ${CTEST_INCLUDE}
-  - make sdsl_examples -k -j 2
-  - make sdsl_tutorials -k -j 2
+  - cmake ${TRAVIS_BUILD_DIR} -DCMAKE_BUILD_TYPE=$MYBUILD -DCMAKE_CXX_FLAGS="-Werror -Wno-missing-field-initializers ${CXX_FLAGS}" -DSDSL_CEREAL=$HAS_CEREAL -DSDSL_HEADER_TEST=$HEADER_TEST
+  - if [[ $HEADER_TEST == "ON" ]];
+    then make sdsl_header_test -k -j 2;
+    else make sdsl_test_targets -k -j 2;
+         travis_wait 90 sleep infinity & ctest . -j 2 --output-on-failure -E ${CTEST_EXCLUDE} -R ${CTEST_INCLUDE};
+         make sdsl_examples -k -j 2;
+         make sdsl_tutorials -k -j 2;
+    fi
 
 after_script:
   - ccache -s

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 ## (5) Options
 option(CODE_COVERAGE "Set ON to add code coverage compile options" OFF)
+option(SDSL_HEADER_TEST "Set ON to run header tests only" OFF)
 option(GENERATE_DOC "Set ON to genrate doxygen API reference in build/doc directory" OFF)
 option(USE_LIBCPP "Use the LLVM libc++ instead of GCC libstdc++ on OS X" ON)
 
@@ -39,6 +40,10 @@ file (GLOB HEADERS "${CMAKE_CURRENT_SOURCE_DIR}/include/sdsl/*.hpp")
 add_custom_target (sdsl SOURCES ${HEADERS})
 
 # (9) test targets 
+if(SDSL_HEADER_TEST)
+  add_subdirectory(test/header)
+  return()
+endif()
 add_subdirectory(test)
 
 # (10) perform extra tasks such as doxygen / packaging and uninstall target 

--- a/include/sdsl/cereal.hpp
+++ b/include/sdsl/cereal.hpp
@@ -8,6 +8,7 @@
 #ifndef INCLUDED_SDSL_CEREAL
 #define INCLUDED_SDSL_CEREAL
 
+#include <type_traits>
 
 #if defined(__has_include)
 	#if __has_include(<cereal/cereal.hpp>)

--- a/include/sdsl/coder_comma.hpp
+++ b/include/sdsl/coder_comma.hpp
@@ -10,6 +10,7 @@
 
 #include <sdsl/bits.hpp>
 #include <sdsl/config.hpp>
+#include <algorithm>
 #include <array>
 #include <math.h>
 

--- a/include/sdsl/cst_iterators.hpp
+++ b/include/sdsl/cst_iterators.hpp
@@ -8,6 +8,7 @@
 #ifndef INCLUDED_SDSL_CST_ITERATORS
 #define INCLUDED_SDSL_CST_ITERATORS
 
+#include <cstdint>
 #include <queue>
 
 namespace sdsl {

--- a/include/sdsl/divsufsort.hpp
+++ b/include/sdsl/divsufsort.hpp
@@ -27,8 +27,7 @@
 #ifndef INCLUDED_SDSL_DIVSUFSORT
 #define INCLUDED_SDSL_DIVSUFSORT
 
-namespace sdsl {
-
+#include <algorithm>
 #include <assert.h>
 #include <stdio.h>
 #include <inttypes.h>
@@ -36,6 +35,8 @@ namespace sdsl {
 #ifdef _OPENMP
 # include <omp.h>
 #endif
+
+namespace sdsl {
 
 #if !defined(UINT8_MAX)
 # define UINT8_MAX (255)

--- a/include/sdsl/sorted_int_stack.hpp
+++ b/include/sdsl/sorted_int_stack.hpp
@@ -183,14 +183,14 @@ void sorted_int_stack::CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
 }
 
 //! Equality operator.
-bool sorted_int_stack::operator==(sorted_int_stack const & other) const noexcept
+inline bool sorted_int_stack::operator==(sorted_int_stack const & other) const noexcept
 {
 	return (m_n == other.m_n) && (m_cnt == other.m_cnt) && (m_top == other.m_top) &&
 	       (m_stack == other.m_stack) && (m_overflow == other.m_overflow);
 }
 
 //! Inequality operator.
-bool sorted_int_stack::operator!=(sorted_int_stack const & other) const noexcept
+inline bool sorted_int_stack::operator!=(sorted_int_stack const & other) const noexcept
 {
 	return !(*this == other);
 }

--- a/include/sdsl/sorted_stack_support.hpp
+++ b/include/sdsl/sorted_stack_support.hpp
@@ -174,14 +174,14 @@ void sorted_stack_support::CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
 }
 
 //! Equality operator.
-bool sorted_stack_support::operator==(sorted_stack_support const & other) const noexcept
+inline bool sorted_stack_support::operator==(sorted_stack_support const & other) const noexcept
 {
 	return (m_n == other.m_n) && (m_cnt == other.m_cnt) && (m_top == other.m_top) &&
 	       (m_stack == other.m_stack);
 }
 
 //! Inequality operator.
-bool sorted_stack_support::operator!=(sorted_stack_support const & other) const noexcept
+inline bool sorted_stack_support::operator!=(sorted_stack_support const & other) const noexcept
 {
 	return !(*this == other);
 }

--- a/test/header/CMakeLists.txt
+++ b/test/header/CMakeLists.txt
@@ -1,0 +1,45 @@
+# Modified version from Bio-Formats
+# https://github.com/openmicroscopy/bioformats/blob/d3bb33eeda23e81f78fd25f658bfc14a4363805f/cpp/cmake/HeaderTest.cmake#L81-L113
+# and SeqAn3
+# https://github.com/seqan/seqan3/blob/c9719852dc2d42cd371bd5c65d3af93935f29f39/test/header/CMakeLists.txt
+add_library (sdsl_test_header INTERFACE)
+set (header_all_target "sdsl_header_test")
+
+file(GLOB SDSL_HEADER_ALL ${CMAKE_CURRENT_BINARY_DIR}/../../include/sdsl/*.hpp)
+
+file (WRITE "${CMAKE_CURRENT_BINARY_DIR}/${header_all_target}.cpp" "int main() {}")
+add_executable (${header_all_target} ${CMAKE_CURRENT_BINARY_DIR}/${header_all_target}.cpp)
+target_link_libraries (${header_all_target} gtest)
+target_link_libraries (${header_all_target} sdsl_test_header)
+add_test (NAME "header/${header_all_target}" COMMAND ${header_all_target})
+
+include_directories(${CMAKE_CURRENT_BINARY_DIR}/../../include
+                    ${gtest_SOURCE_DIR}/include
+)
+
+foreach (header ${SDSL_HEADER_ALL})
+    foreach (repeat 1 2)
+        get_filename_component (header_target_name "${header}" NAME_WE)
+        set (header_target_name "${header_target_name}-${repeat}")
+        set (header_target_source "${CMAKE_CURRENT_BINARY_DIR}/${header_target_name}.cpp")
+        set (header_target "${header_all_target}--${header_target_name}")
+
+        string (REPLACE "-" "__" header_test_name_safe "${header_all_target}, ${header_target}")
+        file (WRITE "${header_target_source}" "
+#include <${header}>
+#include <${header}>
+#include <gtest/gtest.h>
+TEST(${header_test_name_safe}) {}")
+        add_library (${header_target} OBJECT "${header_target_source}")
+        link_libraries(gtest)
+        if (CMAKE_VERSION VERSION_LESS 3.12)
+            target_compile_options (${header_target} PRIVATE $<TARGET_PROPERTY:sdsl_test_header,INTERFACE_COMPILE_OPTIONS>)
+            target_compile_definitions (${header_target} PRIVATE $<TARGET_PROPERTY:sdsl_test_header,INTERFACE_COMPILE_DEFINITIONS>)
+            target_include_directories (${header_target} PRIVATE $<TARGET_PROPERTY:sdsl_test_header,INTERFACE_INCLUDE_DIRECTORIES>)
+            # target_link_libraries (${header_target} PRIVATE $<TARGET_PROPERTY:sdsl_test_header,INTERFACE_LINK_LIBRARIES>)
+        else ()
+            target_link_libraries (${header_target} sdsl_test_header)
+        endif ()
+        target_sources (${header_all_target} PRIVATE $<TARGET_OBJECTS:${header_target}>)
+    endforeach ()
+endforeach ()


### PR DESCRIPTION
When trying to reactivate header tests for the search module in SeqAn3 I encountered some failing SDSL headers (errors which I introduced with the cereal support - the comparison operators for the stack supports).

For this reason I added a header test to the SDSL and fixed the resulting errors.