### PR TITLE
Add plain byte alphabet as a csa alphabet strategy

### DIFF
--- a/include/sdsl/csa_alphabet_strategy.hpp
+++ b/include/sdsl/csa_alphabet_strategy.hpp
@@ -550,6 +550,7 @@ void init_char_bitvector(sd_vector<t_hi_bit_vector, t_select_1, t_select_0> &cha
 class plain_byte_alphabet
 {
 public:
+    //! Helper class for the char2comp and comp2char mapping.
     class mapping_wrapper;
 
     typedef int_vector<>::size_type size_type;
@@ -563,12 +564,14 @@ public:
     typedef byte_alphabet_tag alphabet_category;
     enum { int_width = 8 };
 
-    //! Helper class for the char2comp and comp2char mapping
+    //! Helper class for the char2comp and comp2char mapping.
     class mapping_wrapper
     {
     public:
-        mapping_wrapper() {}
+        //! Default constructor.
+        mapping_wrapper() = default;
 
+        //! Random access operator.
         constexpr char_type operator[](char_type const c) const noexcept
         {
             return c;
@@ -585,15 +588,17 @@ private:
     sigma_type m_sigma; // Effective size of the alphabet.
 
 public:
-    //! Default constructor
-    plain_byte_alphabet() : C(m_C), sigma(m_sigma), m_sigma(0)
+    //! Default constructor.
+    plain_byte_alphabet() :
+        C(m_C), sigma(m_sigma), m_sigma(0)
     {}
 
-    /*! Construct from a byte-stream
+    /*! Construct from a byte-stream.
      *  \param text_buf Byte stream.
      *  \param len      Length of the byte stream.
      */
-    plain_byte_alphabet(int_vector_buffer<8> & text_buf, int_vector_size_type len) : C(m_C), sigma(m_sigma)
+    plain_byte_alphabet(int_vector_buffer<8> & text_buf, int_vector_size_type len) :
+        C(m_C), sigma(m_sigma)
     {
         m_sigma = 0;
         if (0 == len || 0 == text_buf.size())
@@ -629,18 +634,17 @@ public:
         assert(C[sigma] == len);
     }
 
-    plain_byte_alphabet(plain_byte_alphabet const & strat) : C(m_C),
-                                                             sigma(m_sigma),
-                                                             m_C(strat.m_C),
-                                                             m_sigma(strat.m_sigma)
+    //! Copy constructor.
+    plain_byte_alphabet(plain_byte_alphabet const & strat) :
+        C(m_C), sigma(m_sigma), m_C(strat.m_C), m_sigma(strat.m_sigma)
     {}
 
-    plain_byte_alphabet(plain_byte_alphabet && strat) : C(m_C),
-                                                        sigma(m_sigma),
-                                                        m_C(std::move(strat.m_C)),
-                                                        m_sigma(strat.m_sigma)
+    //! Move constructor.
+    plain_byte_alphabet(plain_byte_alphabet && strat) noexcept :
+        C(m_C), sigma(m_sigma), m_C(std::move(strat.m_C)), m_sigma(strat.m_sigma)
     {}
 
+    //! Copy assignment.
     plain_byte_alphabet & operator=(plain_byte_alphabet const & strat)
     {
         if (this != &strat)
@@ -651,17 +655,19 @@ public:
         return *this;
     }
 
-    plain_byte_alphabet & operator=(plain_byte_alphabet && strat)
+    //! Move assignment.
+    plain_byte_alphabet & operator=(plain_byte_alphabet && strat) noexcept
     {
         if (this != &strat)
         {
             m_C = std::move(strat.m_C);
-            m_sigma = std::move(strat.m_sigma);
+            m_sigma = strat.m_sigma;
         }
         return *this;
     }
 
-    size_type serialize(std::ostream & out, structure_tree_node * v, std::string name = "") const
+    //!\cond
+    size_type serialize(std::ostream & out, structure_tree_node * v, std::string const & name = "") const
     {
         structure_tree_node * child = structure_tree::add_child(v, name, util::class_name(*this));
         size_type written_bytes = 0;
@@ -700,6 +706,7 @@ public:
     {
         return !(*this == other);
     }
+    //!\endcond
 };
 
 //! A space-efficient representation for byte alphabets.

--- a/include/sdsl/csa_alphabet_strategy.hpp
+++ b/include/sdsl/csa_alphabet_strategy.hpp
@@ -542,6 +542,166 @@ void init_char_bitvector(sd_vector<t_hi_bit_vector, t_select_1, t_select_0> &cha
     char_bv = std::move(sd_vector<t_hi_bit_vector, t_select_1, t_select_0>(builder));
 }
 
+/*!\brief Provides an alphabet mapping that implements an identity map (i.e. each character is mapped to its rank).
+ * \details This mapping is faster for FM indices and should always be used for ranges containing all characters of the
+ *          underlying alphabet type. Indices based on a text not containing all characters of its alphabet type will
+ *          have a much higher memory footprint using this alphabet mapping.
+ */
+class plain_byte_alphabet
+{
+public:
+    class mapping_wrapper;
+
+    typedef int_vector<>::size_type size_type;
+    typedef mapping_wrapper char2comp_type;
+    typedef mapping_wrapper comp2char_type;
+    typedef int_vector<64> C_type;
+    typedef uint16_t sigma_type;
+    typedef uint8_t char_type;
+    typedef uint8_t comp_char_type;
+    typedef std::string string_type;
+    typedef byte_alphabet_tag alphabet_category;
+    enum { int_width = 8 };
+
+    //! Helper class for the char2comp and comp2char mapping
+    class mapping_wrapper
+    {
+    public:
+        mapping_wrapper() {}
+
+        constexpr char_type operator[](char_type const c) const noexcept
+        {
+            return c;
+        }
+    };
+
+    const char2comp_type char2comp{};
+    const comp2char_type comp2char{};
+    const C_type & C;
+    const sigma_type & sigma;
+
+private:
+    C_type m_C;         // Cumulative counts for the compact alphabet [0..sigma].
+    sigma_type m_sigma; // Effective size of the alphabet.
+
+public:
+    //! Default constructor
+    plain_byte_alphabet() : C(m_C), sigma(m_sigma), m_sigma(0)
+    {}
+
+    /*! Construct from a byte-stream
+     *  \param text_buf Byte stream.
+     *  \param len      Length of the byte stream.
+     */
+    plain_byte_alphabet(int_vector_buffer<8> & text_buf, int_vector_size_type len) : C(m_C), sigma(m_sigma)
+    {
+        m_sigma = 0;
+        if (0 == len || 0 == text_buf.size())
+            return;
+
+        assert(len <= text_buf.size());
+
+        // initialize vectors
+        m_C = int_vector<64>(257, 0);
+        // count occurrences of each symbol
+        for (size_type i = 0; i < len; ++i)
+            ++m_C[text_buf[i]];
+
+        assert(1 == m_C[0]); // null-byte should occur exactly once
+
+        m_sigma = 255;
+        for (int i = 0; i < 256; ++i)
+        {
+            if (m_C[i])
+            {
+                m_sigma = i + 1;
+                // m_C[m_sigma]	= m_C[i];
+                // ++m_sigma;
+            }
+        }
+        // m_C.resize(m_sigma + 1);
+        for (int i = (int) 256; i > 0; --i)
+            m_C[i] = m_C[i - 1];
+        m_C[0] = 0;
+        for (int i = 1; i <= (int) 256; ++i)
+            m_C[i] += m_C[i - 1];
+
+        assert(C[sigma] == len);
+    }
+
+    plain_byte_alphabet(plain_byte_alphabet const & strat) : C(m_C),
+                                                             sigma(m_sigma),
+                                                             m_C(strat.m_C),
+                                                             m_sigma(strat.m_sigma)
+    {}
+
+    plain_byte_alphabet(plain_byte_alphabet && strat) : C(m_C),
+                                                        sigma(m_sigma),
+                                                        m_C(std::move(strat.m_C)),
+                                                        m_sigma(strat.m_sigma)
+    {}
+
+    plain_byte_alphabet & operator=(plain_byte_alphabet const & strat)
+    {
+        if (this != &strat)
+        {
+            plain_byte_alphabet tmp(strat);
+            *this = std::move(tmp);
+        }
+        return *this;
+    }
+
+    plain_byte_alphabet & operator=(plain_byte_alphabet && strat)
+    {
+        if (this != &strat)
+        {
+            m_C = std::move(strat.m_C);
+            m_sigma = std::move(strat.m_sigma);
+        }
+        return *this;
+    }
+
+    size_type serialize(std::ostream & out, structure_tree_node * v, std::string name = "") const
+    {
+        structure_tree_node * child = structure_tree::add_child(v, name, util::class_name(*this));
+        size_type written_bytes = 0;
+        written_bytes += m_C.serialize(out, child, "m_C");
+        written_bytes += write_member(m_sigma, out, child, "m_sigma");
+        structure_tree::add_size(child, written_bytes);
+        return written_bytes;
+    }
+
+    void load(std::istream & in)
+    {
+        m_C.load(in);
+        read_member(m_sigma, in);
+    }
+
+    template <typename archive_t>
+    void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
+    {
+        ar(CEREAL_NVP(m_C));
+        ar(CEREAL_NVP(m_sigma));
+    }
+
+    template <typename archive_t>
+    void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
+    {
+        ar(CEREAL_NVP(m_C));
+        ar(CEREAL_NVP(m_sigma));
+    }
+
+    bool operator==(plain_byte_alphabet const & other) const noexcept
+    {
+        return (m_C == other.m_C) && (m_sigma == other.m_sigma);
+    }
+
+    bool operator!=(plain_byte_alphabet const & other) const noexcept
+    {
+        return !(*this == other);
+    }
+};
+
 //! A space-efficient representation for byte alphabets.
 /*!
  *  The mapping `char2comp` and its inverse `comp2char` is realized internally

--- a/test/search_bidirectional_test.cpp
+++ b/test/search_bidirectional_test.cpp
@@ -23,8 +23,10 @@ using testing::Types;
 typedef Types<
     csa_wt<wt_blcd<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, byte_alphabet>,
     csa_wt<wt_blcd<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, succinct_byte_alphabet<> >,
+    csa_wt<wt_blcd<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, plain_byte_alphabet>,
     csa_wt<wt_hutu<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, byte_alphabet>,
     csa_wt<wt_hutu<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, succinct_byte_alphabet<> >,
+    csa_wt<wt_hutu<>, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, plain_byte_alphabet>,
     csa_wt<wt_hutu<bit_vector_il<> >, 32, 32, sa_order_sa_sampling<>, isa_sampling<>, byte_alphabet>
 > Implementations;
 


### PR DESCRIPTION
We implemented the class `plain_byte_alphabet` and added tests and documentation.

Touches https://github.com/seqan/seqan3/issues/1603