### PR TITLE
[CMAKE,FIX] fix the doxygen build

### DIFF
--- a/extras/CMakeLists.txt
+++ b/extras/CMakeLists.txt
@@ -4,7 +4,7 @@ include(Colors)
 if(GENERATE_DOC)
   find_package(Doxygen)
     if(DOXYGEN_FOUND)
-        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/extras/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
+        configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
         add_custom_target(docs ALL
         ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}

--- a/extras/Doxyfile.in
+++ b/extras/Doxyfile.in
@@ -775,7 +775,7 @@ WARN_LOGFILE           =
 # spaces. See also FILE_PATTERNS and EXTENSION_MAPPING
 # Note: If this tag is empty the current directory is searched.
 
-INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/include @CMAKE_CURRENT_SOURCE_DIR@/README.md
+INPUT                  = @CMAKE_CURRENT_SOURCE_DIR@/../include @CMAKE_CURRENT_SOURCE_DIR@/../README.md
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses
@@ -1677,7 +1677,7 @@ PAPER_TYPE             = a4
 # If left blank no extra packages will be included.
 # This tag requires that the tag GENERATE_LATEX is set to YES.
 
-EXTRA_PACKAGES         = amsfonts amsmath @CMAKE_CURRENT_SOURCE_DIR@/extras/sdsl_definitions
+EXTRA_PACKAGES         = amsfonts amsmath @CMAKE_CURRENT_SOURCE_DIR@/sdsl_definitions
 
 # The LATEX_HEADER tag can be used to specify a personal LaTeX header for the
 # generated LaTeX document. The header should contain everything until the first


### PR DESCRIPTION
Doxygen failed to generate the api documentation, because it searched for header files inside an `extras/include` directory, which does not exist. Our solution is to move the generation code in the CMake file one directory up, so doxygen searches in `include` instead.