### PR TITLE
[FEATURE] EPR wavelettree

### DIFF
--- a/include/sdsl/cereal.hpp
+++ b/include/sdsl/cereal.hpp
@@ -19,6 +19,7 @@
 #include <cereal/archives/xml.hpp>
 #include <cereal/cereal.hpp>
 #include <cereal/details/traits.hpp>
+#include <cereal/types/array.hpp>
 #include <cereal/types/memory.hpp>
 #include <cereal/types/vector.hpp>
 #endif

--- a/include/sdsl/csa_sampling_strategy.hpp
+++ b/include/sdsl/csa_sampling_strategy.hpp
@@ -1007,7 +1007,7 @@ class _fuzzy_isa_sampling_support
     {
         structure_tree_node * child = structure_tree::add_child(v, name, util::class_name(*this));
         size_type written_bytes = 0;
-        written_bytes += m_select_marked_sa.serialize(out, v, "select_marked_sa");
+        written_bytes += m_select_marked_sa.serialize(out, child, "select_marked_sa");
         structure_tree::add_size(child, written_bytes);
         return written_bytes;
     }

--- a/include/sdsl/int_vector.hpp
+++ b/include/sdsl/int_vector.hpp
@@ -1301,6 +1301,8 @@ class int_vector_const_iterator : public int_vector_iterator_base<t_int_vector>
         m_len = it.m_len;
     }
 
+    int_vector_const_iterator & operator=(const int_vector_const_iterator&) = default;
+
     const_reference operator*() const
     {
         if (m_offset + m_len <= 64) { return ((*m_word) >> m_offset) & bits::lo_set[m_len]; }

--- a/include/sdsl/int_vector.hpp
+++ b/include/sdsl/int_vector.hpp
@@ -1301,7 +1301,7 @@ class int_vector_const_iterator : public int_vector_iterator_base<t_int_vector>
         m_len = it.m_len;
     }
 
-    int_vector_const_iterator & operator=(const int_vector_const_iterator&) = default;
+    int_vector_const_iterator & operator=(const int_vector_const_iterator &) = default;
 
     const_reference operator*() const
     {

--- a/include/sdsl/rank_support_int.hpp
+++ b/include/sdsl/rank_support_int.hpp
@@ -4,7 +4,7 @@
 /*! \file rank_support_int.hpp
     \brief rank_support_int.hpp contains classes that support a sdsl::int_vector with constant time rank information.
            Rank is defined as the number of occurrences of a value up to a given position.
-	\author Christopher Pockrandt
+    \author Christopher Pockrandt
 */
 #ifndef INCLUDED_SDSL_RANK_SUPPORT_INT
 #define INCLUDED_SDSL_RANK_SUPPORT_INT
@@ -41,8 +41,8 @@ template <uint8_t alphabet_size>
 class rank_support_int {
 
 public:
-	typedef typename int_vector<>::size_type size_type;
-	typedef typename int_vector<>::value_type value_type;
+    typedef typename int_vector<>::size_type size_type;
+    typedef typename int_vector<>::value_type value_type;
 
     static_assert(alphabet_size > 2, "Rank support is only implemented on int_vectors with an alphabet size of > 2.");
 
@@ -57,12 +57,12 @@ protected:
     }
 
 protected:
-	const int_vector<>* m_v; //!< Pointer to the rank supported bit_vector
+    const int_vector<>* m_v; //!< Pointer to the rank supported bit_vector
     static constexpr uint8_t t_v{alphabet_size};
     static constexpr uint8_t t_b{ceil_log2(alphabet_size)};
-	static constexpr uint64_t even_mask{bm_rec<uint64_t>(bits::lo_set[t_b], t_b * 2, 64)};
-	static constexpr uint64_t carry_select_mask{bm_rec<uint64_t>(1ULL << t_b, t_b * 2, 64)};
-	uint64_t masks[alphabet_size]; // TODO: make constexpr and remove init()
+    static constexpr uint64_t even_mask{bm_rec<uint64_t>(bits::lo_set[t_b], t_b * 2, 64)};
+    static constexpr uint64_t carry_select_mask{bm_rec<uint64_t>(1ULL << t_b, t_b * 2, 64)};
+    uint64_t masks[alphabet_size]; // TODO: make constexpr and remove init()
 
     // Count how often value v or smaller occurs in the word w.
     uint64_t set_positions_prefix(const uint64_t w, const value_type v) const
@@ -144,52 +144,52 @@ protected:
     }
 
 public:
-	//! Constructor
-	/*! \param v The supported int_vector.
-         */
-	rank_support_int(const int_vector<>* v = nullptr);
-	//! Copy constructor
-	rank_support_int(const rank_support_int&) = default;
-	rank_support_int(rank_support_int&&)	  = default;
-	rank_support_int& operator=(const rank_support_int&) = default;
-	rank_support_int& operator=(rank_support_int&&) = default;
-	//! Destructor
-	virtual ~rank_support_int() {}
+    //! Constructor
+    /*! \param v The supported int_vector.
+     */
+    rank_support_int(const int_vector<>* v = nullptr);
+    //! Copy constructor
+    rank_support_int(const rank_support_int&) = default;
+    rank_support_int(rank_support_int&&) = default;
+    rank_support_int& operator=(const rank_support_int&) = default;
+    rank_support_int& operator=(rank_support_int&&) = default;
+    //! Destructor
+    virtual ~rank_support_int() {}
 
-	//! Answers rank queries for the supported int_vector.
-	/*!	\param i Argument for the length of the prefix v[0..i-1].
-            \param v Argument which value to count.
-        	\returns Number of occurrences of v in the prefix [0..i-1] of the supported int_vector.
-        	\note Method init has to be called before the first call of rank.
-        	\sa init
-         */
-	virtual size_type rank(const size_type i, const value_type v) const = 0;
-	//! Alias for rank(idx, v)
-	virtual size_type operator()(const size_type idx, const value_type v) const = 0;
-	//! Answers rank queries for the supported int_vector.
-	/*!	\param i Argument for the length of the prefix v[0..i-1].
-            \param v Argument which value (including smaller values) to count.
-        	\returns Number of occurrences of elements smaller or equal to v in the prefix [0..i-1] of the supported int_vector.
-        	\note Method init has to be called before the first call of rank.
-        	\sa init
-         */
-	virtual size_type prefix_rank(const size_type i, const value_type v) const = 0;
-	//! Serializes rank_support_int.
-	/*! \param out Out-Stream to serialize the data to.
+    //! Answers rank queries for the supported int_vector.
+    /*!	\param i Argument for the length of the prefix v[0..i-1].
+     *  \param v Argument which value to count.
+     *  \returns Number of occurrences of v in the prefix [0..i-1] of the supported int_vector.
+     *  \note Method init has to be called before the first call of rank.
+     *  \sa init
+     */
+    virtual size_type rank(const size_type i, const value_type v) const = 0;
+    //! Alias for rank(idx, v)
+    virtual size_type operator()(const size_type idx, const value_type v) const = 0;
+    //! Answers rank queries for the supported int_vector.
+    /*!	\param i Argument for the length of the prefix v[0..i-1].
+     *  \param v Argument which value (including smaller values) to count.
+     *  \returns Number of occurrences of elements smaller or equal to v in the prefix [0..i-1] of the supported int_vector.
+     *  \note Method init has to be called before the first call of rank.
+     *  \sa init
+     */
+    virtual size_type prefix_rank(const size_type i, const value_type v) const = 0;
+    //! Serializes rank_support_int.
+    /*! \param out Out-Stream to serialize the data to.
         */
-	virtual size_type
-	serialize(std::ostream& out, structure_tree_node* v, const std::string name) const = 0;
-	//! Loads the rank_support_int.
-	/*! \param in In-Stream to load the rank_support_int data from.
-            \param v The supported int_vector.
-         */
-	virtual void load(std::istream& in, const int_vector<>* v = nullptr) = 0;
-	//! Sets the supported int_vector to the given pointer.
-	/*! \param v The new int_vector to support.
-         *  \note Method init has to be called before the next call of rank or prefix_rank.
-         *  \sa init, rank, prefix_rank
-         */
-	virtual void set_vector(const int_vector<>* v = nullptr) = 0;
+    virtual size_type
+    serialize(std::ostream& out, structure_tree_node* v, const std::string name) const = 0;
+    //! Loads the rank_support_int.
+    /*! \param in In-Stream to load the rank_support_int data from.
+     *  \param v The supported int_vector.
+     */
+    virtual void load(std::istream& in, const int_vector<>* v = nullptr) = 0;
+    //! Sets the supported int_vector to the given pointer.
+    /*! \param v The new int_vector to support.
+     *  \note Method init has to be called before the next call of rank or prefix_rank.
+     *  \sa init, rank, prefix_rank
+     */
+    virtual void set_vector(const int_vector<>* v = nullptr) = 0;
 };
 
 template <uint8_t alphabet_type>

--- a/include/sdsl/rank_support_int.hpp
+++ b/include/sdsl/rank_support_int.hpp
@@ -1,11 +1,11 @@
 // Copyright (c) 2016, the SDSL Project Authors.  All rights reserved.
 // Please see the AUTHORS file for details.  Use of this source code is governed
 // by a BSD license that can be found in the LICENSE file.
-/*! \file rank_support_int.hpp
-    \brief rank_support_int.hpp contains classes that support a sdsl::int_vector with constant time rank information.
-           Rank is defined as the number of occurrences of a value up to a given position.
-    \author Christopher Pockrandt
-*/
+/*!\file rank_support_int.hpp
+ * \brief rank_support_int.hpp contains classes that support a sdsl::int_vector with constant time rank information.
+ *        Rank is defined as the number of occurrences of a value up to a given position.
+ * \author Christopher Pockrandt
+ */
 #ifndef INCLUDED_SDSL_RANK_SUPPORT_INT
 #define INCLUDED_SDSL_RANK_SUPPORT_INT
 
@@ -13,19 +13,16 @@
  * This group contains data structures which support an sdsl::int_vector with the rank method.
  */
 
-#include "int_vector.hpp"
-#include "uint128_t.hpp"
+#include <sdsl/int_vector.hpp>
+#include <sdsl/uint128_t.hpp>
 
 // TODO: benchmark the use of compiler hints for branch prediction
-#define likely(x)       __builtin_expect((x),1)
-#define unlikely(x)     __builtin_expect((x),0)
+#define likely(x) __builtin_expect((x), 1)
+#define unlikely(x) __builtin_expect((x), 0)
 
 //! Namespace for the succinct data structure library.
-namespace sdsl {
-
-//! The base class of classes supporting rank_queries for a sdsl::int_vector in constant time.
-/*!
-*/
+namespace sdsl
+{
 
 constexpr size_t floor_log2(size_t const n)
 {
@@ -37,17 +34,18 @@ constexpr size_t ceil_log2(size_t const n)
     return (n == 1) ? 0 : floor_log2(n - 1) + 1;
 }
 
+//!\brief The base class of classes supporting rank_queries for a sdsl::int_vector in constant time.
 template <uint8_t alphabet_size>
-class rank_support_int {
+class rank_support_int
+{
 
-public:
+  public:
     typedef typename int_vector<>::size_type size_type;
     typedef typename int_vector<>::value_type value_type;
 
     static_assert(alphabet_size > 2, "Rank support is only implemented on int_vectors with an alphabet size of > 2.");
 
-protected:
-
+  protected:
     // Constructs a bit mask with the pattern w of a given length.
     // It is concatenated until the length of the bitmask reaches max_length.
     template <typename uintX_t>
@@ -63,42 +61,40 @@ protected:
         for (value_type v = 0; v < alphabet_size; ++v)
         {
             masks[v] = v;
-            for (uint8_t i = sigma_bits * 2; i < 64; i <<= 1)
-                masks[v] |= masks[v] << i;
+            for (uint8_t i = sigma_bits * 2; i < 64; i <<= 1) masks[v] |= masks[v] << i;
         }
 
         uint64_t tmp_carry = masks[1];
-        for (value_type v = 0; v < alphabet_size; ++v)
-            masks[v] |= tmp_carry << sigma_bits;
+        for (value_type v = 0; v < alphabet_size; ++v) masks[v] |= tmp_carry << sigma_bits;
 
         return masks;
     }
 
-protected:
-    static constexpr uint8_t sigma{alphabet_size};
-    static constexpr uint8_t sigma_bits{ceil_log2(alphabet_size)};
-    static constexpr uint8_t bits_per_word{(64 / sigma_bits) * sigma_bits};
-    static constexpr uint64_t even_mask{bm_rec<uint64_t>(bits::lo_set[sigma_bits], sigma_bits * 2, 64)};
-    static constexpr uint64_t carry_select_mask{bm_rec<uint64_t>(1ULL << sigma_bits, sigma_bits * 2, 64)};
+  protected:
+    static constexpr uint8_t sigma{ alphabet_size };
+    static constexpr uint8_t sigma_bits{ ceil_log2(alphabet_size) };
+    static constexpr uint8_t bits_per_word{ (64 / sigma_bits) * sigma_bits };
+    static constexpr uint64_t even_mask{ bm_rec<uint64_t>(bits::lo_set[sigma_bits], sigma_bits * 2, 64) };
+    static constexpr uint64_t carry_select_mask{ bm_rec<uint64_t>(1ULL << sigma_bits, sigma_bits * 2, 64) };
     static const std::array<uint64_t, alphabet_size> masks;
 
-    const int_vector<>* m_v; //!< Pointer to the rank supported bit_vector
+    const int_vector<> * m_v; //!< Pointer to the rank supported bit_vector
 
-public:
+  public:
     //! Constructor
     /*! \param v The supported int_vector.
      */
-    rank_support_int(const int_vector<>* v = nullptr)
+    rank_support_int(const int_vector<> * v = nullptr)
     { // Check that the actual width of the vector has same size as sigma_bits.
         assert((v != nullptr) ? sigma_bits == v->width() : true);
         m_v = v;
     }
 
     //! Copy constructor
-    rank_support_int(const rank_support_int&) = default;
-    rank_support_int(rank_support_int&&) = default;
-    rank_support_int& operator=(const rank_support_int&) = default;
-    rank_support_int& operator=(rank_support_int&&) = default;
+    rank_support_int(const rank_support_int &) = default;
+    rank_support_int(rank_support_int &&) = default;
+    rank_support_int & operator=(const rank_support_int &) = default;
+    rank_support_int & operator=(rank_support_int &&) = default;
     //! Destructor
     virtual ~rank_support_int() {}
 
@@ -117,31 +113,30 @@ public:
     //! Answers rank queries for the supported int_vector.
     /*!	\param i Argument for the length of the prefix v[0..i-1].
      *  \param v Argument which value (including smaller values) to count.
-     *  \returns Number of occurrences of elements smaller or equal to v in the prefix [0..i-1] of the supported int_vector.
-     *  \note Method init has to be called before the first call of rank.
-     *  \sa init
+     *  \returns Number of occurrences of elements smaller or equal to v in the prefix [0..i-1] of the supported
+     * int_vector. \note Method init has to be called before the first call of rank. \sa init
      */
     virtual size_type prefix_rank(const size_type i, const value_type v) const = 0;
 
     //! Serializes rank_support_int.
     /*! \param out Out-Stream to serialize the data to.
      */
-    virtual size_type serialize(std::ostream& out, structure_tree_node* v, const std::string name) const = 0;
+    virtual size_type serialize(std::ostream & out, structure_tree_node * v, const std::string name) const = 0;
 
     //! Loads the rank_support_int.
     /*! \param in In-Stream to load the rank_support_int data from.
      *  \param v The supported int_vector.
      */
-    virtual void load(std::istream& in, const int_vector<>* v = nullptr) = 0;
+    virtual void load(std::istream & in, const int_vector<> * v = nullptr) = 0;
 
     //! Sets the supported int_vector to the given pointer.
     /*! \param v The new int_vector to support.
      *  \note Method init has to be called before the next call of rank or prefix_rank.
      *  \sa init, rank, prefix_rank
      */
-    virtual void set_vector(const int_vector<>* v = nullptr) = 0;
+    virtual void set_vector(const int_vector<> * v = nullptr) = 0;
 
-protected:
+  protected:
     // Mask the set prefix positions.
     static constexpr uint64_t mask_prefix(value_type const v, uint64_t const w_even, uint64_t const w_odd) noexcept
     {
@@ -156,7 +151,7 @@ protected:
     // Count how often value v or smaller occurs in the word w.
     static constexpr uint64_t set_positions_prefix(const uint64_t w, const value_type v) noexcept
     {
-        uint64_t const w_even = even_mask & w; // retrieve even positions
+        uint64_t const w_even = even_mask & w;                // retrieve even positions
         uint64_t const w_odd = even_mask & (w >> sigma_bits); // retrieve odd positions
         return mask_prefix(v, w_even, w_odd);
     }
@@ -167,7 +162,7 @@ protected:
     {
         assert(v > 0);
         // optimiyed version of set_positions(w, v) - set_positions(w, v - 1)
-        uint64_t const w_even = even_mask & w; // retrieve even positions
+        uint64_t const w_even = even_mask & w;                // retrieve even positions
         uint64_t const w_odd = even_mask & (w >> sigma_bits); // retrieve odd positions
         uint64_t res = ((masks[v] - w_even) & ~(masks[v - 1] - w_even)) & carry_select_mask;
         res |= (((masks[v] - w_odd) & ~(masks[v - 1] - w_odd)) & carry_select_mask) << 1;
@@ -175,17 +170,17 @@ protected:
     }
 
     // Counts the occurrences of elements smaller or equal to v in the word starting at data up to position idx.
-    template <typename ...value_t>
+    template <typename... value_t>
     static constexpr std::array<uint64_t, sizeof...(value_t)> word_prefix_rank(const uint64_t word,
                                                                                const size_type bit_pos,
-                                                                               const value_t ...values) noexcept
+                                                                               const value_t... values) noexcept
     {
         uint64_t const mask = bits::lo_set[(bit_pos % bits_per_word) + 1];
 
-        uint64_t const w_even = even_mask & word; // retrieve even positions
+        uint64_t const w_even = even_mask & word;                // retrieve even positions
         uint64_t const w_odd = even_mask & (word >> sigma_bits); // retrieve odd positions
 
-        return {(bits::cnt(mask_prefix(values, w_even, w_odd) & mask))...};
+        return { (bits::cnt(mask_prefix(values, w_even, w_odd) & mask))... };
     }
 
     // Counts the occurrences of elements smaller or equal to v in the word starting at data up to position idx.
@@ -211,7 +206,7 @@ protected:
     }
 
     // Returns the word a the given word position.
-    static constexpr uint64_t extract_word(const uint64_t* data, const size_type word_position) noexcept
+    static constexpr uint64_t extract_word(const uint64_t * data, const size_type word_position) noexcept
     {
         return *(data + word_position);
     }
@@ -222,7 +217,7 @@ const std::array<uint64_t, alphabet_size> rank_support_int<alphabet_size>::masks
 
 } // end namespace sdsl
 
-#include "rank_support_int_v.hpp"
-#include "rank_support_int_scan.hpp"
+#include <sdsl/rank_support_int_scan.hpp>
+#include <sdsl/rank_support_int_v.hpp>
 
 #endif // end file

--- a/include/sdsl/rank_support_int.hpp
+++ b/include/sdsl/rank_support_int.hpp
@@ -1,0 +1,206 @@
+// Copyright (c) 2016, the SDSL Project Authors.  All rights reserved.
+// Please see the AUTHORS file for details.  Use of this source code is governed
+// by a BSD license that can be found in the LICENSE file.
+/*! \file rank_support_int.hpp
+    \brief rank_support_int.hpp contains classes that support a sdsl::int_vector with constant time rank information.
+           Rank is defined as the number of occurrences of a value up to a given position.
+	\author Christopher Pockrandt
+*/
+#ifndef INCLUDED_SDSL_RANK_SUPPORT_INT
+#define INCLUDED_SDSL_RANK_SUPPORT_INT
+
+/** \defgroup rank_support_group Rank Support (RS)
+ * This group contains data structures which support an sdsl::int_vector with the rank method.
+ */
+
+#include "int_vector.hpp"
+#include "uint128_t.hpp"
+
+// TODO: benchmark the use of compiler hints for branch prediction
+#define likely(x)       __builtin_expect((x),1)
+#define unlikely(x)     __builtin_expect((x),0)
+
+//! Namespace for the succinct data structure library.
+namespace sdsl {
+
+//! The base class of classes supporting rank_queries for a sdsl::int_vector in constant time.
+/*!
+*/
+
+constexpr size_t floor_log2(size_t const n)
+{
+    return (n == 1) ? 0 : 1 + floor_log2(n >> 1);
+}
+
+constexpr size_t ceil_log2(size_t const n)
+{
+    return (n == 1) ? 0 : floor_log2(n - 1) + 1;
+}
+
+template <uint8_t alphabet_size>
+class rank_support_int {
+
+public:
+	typedef typename int_vector<>::size_type size_type;
+	typedef typename int_vector<>::value_type value_type;
+
+    static_assert(alphabet_size > 2, "Rank support is only implemented on int_vectors with an alphabet size of > 2.");
+
+protected:
+
+    // Constructs a bit mask with the pattern w of a given length.
+    // It is concatenated until the length of the bitmask reaches max_length.
+    template <typename uintX_t>
+    static constexpr uintX_t bm_rec(const uintX_t w, const uint8_t length, const uint8_t max_length)
+    {
+        return (length >= max_length) ? w : bm_rec(w | (w << length), length << 1, max_length);
+    }
+
+protected:
+	const int_vector<>* m_v; //!< Pointer to the rank supported bit_vector
+    static constexpr uint8_t t_v{alphabet_size};
+    static constexpr uint8_t t_b{ceil_log2(alphabet_size)};
+	static constexpr uint64_t even_mask{bm_rec<uint64_t>(bits::lo_set[t_b], t_b * 2, 64)};
+	static constexpr uint64_t carry_select_mask{bm_rec<uint64_t>(1ULL << t_b, t_b * 2, 64)};
+	uint64_t masks[alphabet_size]; // TODO: make constexpr and remove init()
+
+    // Count how often value v or smaller occurs in the word w.
+    uint64_t set_positions_prefix(const uint64_t w, const value_type v) const
+    {
+        uint64_t const w_even = even_mask & w; // retrieve even positions
+        uint64_t const w_odd = even_mask & (w >> t_b); // retrieve odd positions
+        // every bit that will be set corresponds to an element <= v
+        // because the preset bit to the left in the precomputed bitmask is not eliminated by the carry bit during the subtraction
+        uint64_t res = (masks[v] - w_even) & carry_select_mask;
+        // since alphabet_size is > 2 and an element uses at least 2 bits, we can shift the odd positions by one to the left
+        // and it is guaranteed that when adding both with OR that no bits that are set will overlap.
+        res |= ((masks[v] - w_odd) & carry_select_mask) << 1;
+        return res;
+    }
+
+    // Count how often value v occurs in the word w.
+    // Cannot be called on v = 0. Call set_positions_prefix(w, 0) instead.
+    uint64_t set_positions(const uint64_t w, const value_type v) const
+    {
+        assert(v > 0);
+        // optimiyed version of set_positions(w, v) - set_positions(w, v - 1)
+        uint64_t const w_even = even_mask & w; // retrieve even positions
+        uint64_t const w_odd = even_mask & (w >> t_b); // retrieve odd positions
+        uint64_t res = ((masks[v] - w_even) & ~(masks[v - 1] - w_even)) & carry_select_mask;
+        res |= (((masks[v] - w_odd) & ~(masks[v - 1] - w_odd)) & carry_select_mask) << 1;
+        return res;
+    }
+
+    // Counts the occurrences of elements smaller or equal to v in the word starting at data up to position idx.
+    uint32_t word_prefix_rank(const uint64_t* data, const size_type idx, const value_type v) const
+    {
+        size_type const bit_pos = idx * t_b;
+        uint64_t const w = *(data + (bit_pos >> 6));
+        return bits::cnt(set_positions_prefix(w, v) & bits::lo_set[(bit_pos & 0x3F) + 1]);
+    }
+
+    // Counts the occurrences of elements smaller or equal to v in the word starting at data up to position idx.
+    // Cannot be called on v = 0. Call word_prefix_rank(data, idx, 0) instead.
+    uint32_t word_rank(const uint64_t* data, const size_type idx, const value_type v) const
+    {
+        size_type const bit_pos = idx * t_b;
+        uint64_t const w = *(data + (bit_pos >> 6));
+        return bits::cnt(set_positions(w, v) & bits::lo_set[(bit_pos & 0x3F) + 1]);
+    }
+
+    // Counts the occurrences of v in the word starting at data up to position idx.
+    uint32_t full_word_prefix_rank(const uint64_t* data, const size_type word_pos, const value_type v) const
+    {
+        uint64_t const w = *(data + word_pos);
+        return bits::cnt(set_positions_prefix(w, v));
+    }
+
+    // Counts the occurrences of v in the word starting at data up to position idx.
+    // Cannot be called on v = 0. Call full_word_prefix_rank(data, word_pos, 0) instead.
+    uint32_t full_word_rank(const uint64_t* data, const size_type word_pos, const value_type v) const
+    {
+        uint64_t const w = *(data + word_pos);
+        return bits::cnt(set_positions(w, v));
+    }
+
+    // Constructs a bitmask for each value of the alphabet.
+    void init(const int_vector<>* v)
+    {
+        if (v != nullptr) {
+            assert(t_b == v->width());
+            m_v = v;
+
+            for (value_type v = 0; v < alphabet_size; ++v)
+            {
+                masks[v] = v;
+                for (uint8_t i = t_b * 2; i < 64; i <<= 1)
+                    masks[v] |= masks[v] << i;
+            }
+
+            uint64_t tmp_carry = masks[1];
+            for (value_type v = 0; v < alphabet_size; ++v)
+                masks[v] |= tmp_carry << t_b;
+        }
+    }
+
+public:
+	//! Constructor
+	/*! \param v The supported int_vector.
+         */
+	rank_support_int(const int_vector<>* v = nullptr);
+	//! Copy constructor
+	rank_support_int(const rank_support_int&) = default;
+	rank_support_int(rank_support_int&&)	  = default;
+	rank_support_int& operator=(const rank_support_int&) = default;
+	rank_support_int& operator=(rank_support_int&&) = default;
+	//! Destructor
+	virtual ~rank_support_int() {}
+
+	//! Answers rank queries for the supported int_vector.
+	/*!	\param i Argument for the length of the prefix v[0..i-1].
+            \param v Argument which value to count.
+        	\returns Number of occurrences of v in the prefix [0..i-1] of the supported int_vector.
+        	\note Method init has to be called before the first call of rank.
+        	\sa init
+         */
+	virtual size_type rank(const size_type i, const value_type v) const = 0;
+	//! Alias for rank(idx, v)
+	virtual size_type operator()(const size_type idx, const value_type v) const = 0;
+	//! Answers rank queries for the supported int_vector.
+	/*!	\param i Argument for the length of the prefix v[0..i-1].
+            \param v Argument which value (including smaller values) to count.
+        	\returns Number of occurrences of elements smaller or equal to v in the prefix [0..i-1] of the supported int_vector.
+        	\note Method init has to be called before the first call of rank.
+        	\sa init
+         */
+	virtual size_type prefix_rank(const size_type i, const value_type v) const = 0;
+	//! Serializes rank_support_int.
+	/*! \param out Out-Stream to serialize the data to.
+        */
+	virtual size_type
+	serialize(std::ostream& out, structure_tree_node* v, const std::string name) const = 0;
+	//! Loads the rank_support_int.
+	/*! \param in In-Stream to load the rank_support_int data from.
+            \param v The supported int_vector.
+         */
+	virtual void load(std::istream& in, const int_vector<>* v = nullptr) = 0;
+	//! Sets the supported int_vector to the given pointer.
+	/*! \param v The new int_vector to support.
+         *  \note Method init has to be called before the next call of rank or prefix_rank.
+         *  \sa init, rank, prefix_rank
+         */
+	virtual void set_vector(const int_vector<>* v = nullptr) = 0;
+};
+
+template <uint8_t alphabet_type>
+inline rank_support_int<alphabet_type>::rank_support_int(const int_vector<>* v)
+{
+    init(v);
+}
+
+} // end namespace sdsl
+
+#include "rank_support_int_v.hpp"
+#include "rank_support_int_scan.hpp"
+
+#endif // end file

--- a/include/sdsl/rank_support_int.hpp
+++ b/include/sdsl/rank_support_int.hpp
@@ -140,18 +140,23 @@ public:
     virtual void set_vector(const int_vector<>* v = nullptr) = 0;
 
 protected:
+    // Mask the set prefix positions.
+    static constexpr uint64_t mask_prefix(value_type const v, uint64_t const w_even, uint64_t const w_odd) noexcept
+    {
+        // every bit that will be set corresponds to an element <= v
+        // because the preset bit to the left in the precomputed bitmask is not eliminated by the carry bit during the
+        // subtraction.
+        // since alphabet_size is > 2 and an element uses at least 2 bits, we can shift the odd positions by one to the
+        // left and it is guaranteed that when adding both with OR that no bits that are set will overlap.
+        return ((masks[v] - w_even) & carry_select_mask) | (((masks[v] - w_odd) & carry_select_mask) << 1);
+    }
+
     // Count how often value v or smaller occurs in the word w.
     static constexpr uint64_t set_positions_prefix(const uint64_t w, const value_type v) noexcept
     {
         uint64_t const w_even = even_mask & w; // retrieve even positions
         uint64_t const w_odd = even_mask & (w >> sigma_bits); // retrieve odd positions
-        // every bit that will be set corresponds to an element <= v
-        // because the preset bit to the left in the precomputed bitmask is not eliminated by the carry bit during the subtraction
-        uint64_t res = (masks[v] - w_even) & carry_select_mask;
-        // since alphabet_size is > 2 and an element uses at least 2 bits, we can shift the odd positions by one to the left
-        // and it is guaranteed that when adding both with OR that no bits that are set will overlap.
-        res |= ((masks[v] - w_odd) & carry_select_mask) << 1;
-        return res;
+        return mask_prefix(v, w_even, w_odd);
     }
 
     // Count how often value v occurs in the word w.
@@ -167,66 +172,46 @@ protected:
         return res;
     }
 
-    static constexpr uint64_t prefix_positions(value_type const v, uint64_t const w_even, uint64_t const w_odd) noexcept
-    {
-        // since alphabet_size is > 2 and an element uses at least 2 bits, we can shift the odd positions by one to the
-        // left and it is guaranteed that when adding both with OR that no bits that are set will overlap.
-        return ((masks[v] - w_even) & carry_select_mask) | (((masks[v] - w_odd) & carry_select_mask) << 1);
-    }
-
+    // Counts the occurrences of elements smaller or equal to v in the word starting at data up to position idx.
     template <typename ...value_t>
-    static constexpr std::array<uint64_t, sizeof...(value_t)> word_prefix_rank2(const uint64_t word,
-                                                                                const size_type bit_pos,
-                                                                                const value_t ...values) noexcept
+    static constexpr std::array<uint64_t, sizeof...(value_t)> word_prefix_rank(const uint64_t word,
+                                                                               const size_type bit_pos,
+                                                                               const value_t ...values) noexcept
     {
         uint64_t const mask = bits::lo_set[(bit_pos % bits_per_word) + 1];
 
         uint64_t const w_even = even_mask & word; // retrieve even positions
         uint64_t const w_odd = even_mask & (word >> sigma_bits); // retrieve odd positions
-        // every bit that will be set corresponds to an element <= v
-        // because the preset bit to the left in the precomputed bitmask is not eliminated by the carry bit during the subtraction
 
-        return {(bits::cnt(prefix_positions(values, w_even, w_odd) & mask))...};
-    }
-
-    // Counts the occurrences of elements smaller or equal to v in the word starting at data up to position idx.
-    uint32_t word_prefix_rank(const uint64_t* data, const size_type idx, const value_type v) const
-    {
-        size_type const bit_pos = idx * sigma_bits;
-        return word_prefix_rank2(*(data + (bit_pos / bits_per_word)), bit_pos, v)[0];
-        // uint64_t const w = *(data + (bit_pos >> 6));
-        // return bits::cnt(set_positions_prefix(w, v) & bits::lo_set[(bit_pos & 0x3F) + 1]);
+        return {(bits::cnt(mask_prefix(values, w_even, w_odd) & mask))...};
     }
 
     // Counts the occurrences of elements smaller or equal to v in the word starting at data up to position idx.
     // Cannot be called on v = 0. Call word_prefix_rank(data, idx, 0) instead.
-    uint32_t word_rank(const uint64_t* data, const size_type idx, const value_type v) const
+    static constexpr uint32_t word_rank(const uint64_t word, const size_type bit_pos, const value_type v) noexcept
     {
-        size_type const bit_pos = idx * sigma_bits;
-        uint64_t const w = *(data + (bit_pos >> 6)); // why bit_pos >> 6 == bit_pos / 2^6 =? bit_pos / 64. But this only works if we assume that the words are packed.
-        return bits::cnt(set_positions(w, v) & bits::lo_set[(bit_pos & 0x3F) + 1]); // And then we try to get some value from the bit position?
-    }
-
-    // Counts the occurrences of v in the word starting at data up to position idx.
-    uint32_t full_word_prefix_rank2(const uint64_t word, const value_type v) const
-    {
-        return bits::cnt(set_positions_prefix(word, v));
+        return bits::cnt(set_positions(word, v) & bits::lo_set[(bit_pos & 0x3F) + 1]);
     }
 
     // Needed by rank_support_int_scan
     // Counts the occurrences of v in the word starting at data up to position idx.
-    uint32_t full_word_prefix_rank(const uint64_t* data, const size_type word_pos, const value_type v) const
+    static constexpr uint32_t full_word_prefix_rank(const uint64_t word, const value_type v) noexcept
     {
-        uint64_t const w = *(data + word_pos);
-        return bits::cnt(set_positions_prefix(w, v));
+        return bits::cnt(set_positions_prefix(word, v));
     }
 
     // Counts the occurrences of v in the word starting at data up to position idx.
     // Cannot be called on v = 0. Call full_word_prefix_rank(data, word_pos, 0) instead.
-    uint32_t full_word_rank(const uint64_t* data, const size_type word_pos, const value_type v) const
+    static constexpr uint32_t full_word_rank(const uint64_t word, const value_type v) noexcept
     {
-        uint64_t const w = *(data + word_pos);
-        return bits::cnt(set_positions(w, v));
+
+        return bits::cnt(set_positions(word, v));
+    }
+
+    // Returns the word a the given word position.
+    static constexpr uint64_t extract_word(const uint64_t* data, const size_type word_position) noexcept
+    {
+        return *(data + word_position);
     }
 };
 

--- a/include/sdsl/rank_support_int.hpp
+++ b/include/sdsl/rank_support_int.hpp
@@ -56,13 +56,7 @@ protected:
         return (length >= max_length) ? w : bm_rec(w | (w << length), length << 1, max_length);
     }
 
-protected:
-    static constexpr uint8_t sigma{alphabet_size};
-    static constexpr uint8_t sigma_bits{ceil_log2(alphabet_size)};
-    static constexpr uint8_t bits_per_word{(64 / sigma_bits) * sigma_bits};
-    static constexpr uint64_t even_mask{bm_rec<uint64_t>(bits::lo_set[sigma_bits], sigma_bits * 2, 64)};
-    static constexpr uint64_t carry_select_mask{bm_rec<uint64_t>(1ULL << sigma_bits, sigma_bits * 2, 64)};
-    static constexpr std::array<uint64_t, alphabet_size> masks = [] () constexpr
+    static std::array<uint64_t, alphabet_size> generate_mask_array()
     {
         std::array<uint64_t, alphabet_size> masks{};
 
@@ -78,7 +72,15 @@ protected:
             masks[v] |= tmp_carry << sigma_bits;
 
         return masks;
-    }();
+    }
+
+protected:
+    static constexpr uint8_t sigma{alphabet_size};
+    static constexpr uint8_t sigma_bits{ceil_log2(alphabet_size)};
+    static constexpr uint8_t bits_per_word{(64 / sigma_bits) * sigma_bits};
+    static constexpr uint64_t even_mask{bm_rec<uint64_t>(bits::lo_set[sigma_bits], sigma_bits * 2, 64)};
+    static constexpr uint64_t carry_select_mask{bm_rec<uint64_t>(1ULL << sigma_bits, sigma_bits * 2, 64)};
+    static const std::array<uint64_t, alphabet_size> masks;
 
     const int_vector<>* m_v; //!< Pointer to the rank supported bit_vector
 
@@ -214,6 +216,9 @@ protected:
         return *(data + word_position);
     }
 };
+
+template <uint8_t alphabet_size>
+const std::array<uint64_t, alphabet_size> rank_support_int<alphabet_size>::masks = generate_mask_array();
 
 } // end namespace sdsl
 

--- a/include/sdsl/rank_support_int_scan.hpp
+++ b/include/sdsl/rank_support_int_scan.hpp
@@ -26,80 +26,80 @@ namespace sdsl {
 template <uint8_t alphabet_size>
 class rank_support_int_scan : public rank_support_int<alphabet_size> {
 public:
-	typedef int_vector<> int_vector_type;
+    typedef int_vector<> int_vector_type;
     typedef typename rank_support_int<alphabet_size>::size_type size_type;
     typedef typename rank_support_int<alphabet_size>::value_type value_type;
 
 public:
-	explicit rank_support_int_scan(const int_vector<>* v = nullptr) : rank_support_int<alphabet_size>(v){};
-	rank_support_int_scan(const rank_support_int_scan& rs) = default;
-	rank_support_int_scan(rank_support_int_scan&& rs)	  = default;
-	rank_support_int_scan& operator=(const rank_support_int_scan& rs) = default;
-	rank_support_int_scan& operator=(rank_support_int_scan&& rs) = default;
-	size_type rank(size_type idx, const value_type v) const;
-	size_type operator()(size_type idx, const value_type v) const { return rank(idx, v); };
-	size_type prefix_rank(size_type idx, const value_type v) const;
-	size_type size() const { return this->m_v->size(); };
-	size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
-	{
-		return serialize_empty_object(out, v, name, this);
-	}
-	void load(std::istream&, const int_vector<>* v = nullptr) { this->m_v = v; this->init(v); }
-	void set_vector(const int_vector<>* v = nullptr) { this->m_v = v; }
+    explicit rank_support_int_scan(const int_vector<>* v = nullptr) : rank_support_int<alphabet_size>(v){};
+    rank_support_int_scan(const rank_support_int_scan& rs) = default;
+    rank_support_int_scan(rank_support_int_scan&& rs) = default;
+    rank_support_int_scan& operator=(const rank_support_int_scan& rs) = default;
+    rank_support_int_scan& operator=(rank_support_int_scan&& rs) = default;
+    size_type rank(size_type idx, const value_type v) const;
+    size_type operator()(size_type idx, const value_type v) const { return rank(idx, v); };
+    size_type prefix_rank(size_type idx, const value_type v) const;
+    size_type size() const { return this->m_v->size(); };
+    size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
+    {
+        return serialize_empty_object(out, v, name, this);
+    }
+    void load(std::istream&, const int_vector<>* v = nullptr) { this->m_v = v; this->init(v); }
+    void set_vector(const int_vector<>* v = nullptr) { this->m_v = v; }
 };
 
 //! Counts the occurrences of v in the prefix [0..idx-1]
 /*! \param idx Argument for the length of the prefix v[0..idx-1].
-	 *  \param v Argument which value to count.
-     *  \sa prefix_rank
-     */
+ *  \param v Argument which value to count.
+ *  \sa prefix_rank
+ */
 template <uint8_t alphabet_size>
 inline typename rank_support_int_scan<alphabet_size>::size_type
 rank_support_int_scan<alphabet_size>::rank(const size_type idx, const value_type v) const
 {
-	assert(v < this->t_v);
-	assert(this->m_v != nullptr);
-	assert(idx <= this->m_v->size());
+    assert(v < this->t_v);
+    assert(this->m_v != nullptr);
+    assert(idx <= this->m_v->size());
 
-	if (unlikely(v == 0))
-		return prefix_rank(idx, v);
+    if (unlikely(v == 0))
+        return prefix_rank(idx, v);
 
-	const uint64_t* p = this->m_v->data();
-	size_type i = 0;
-	size_type result = 0;
-	size_type word_pos = (idx * this->t_b) >> 6;
-	while (i < word_pos) {
-		result += this->full_word_rank(p, i, v);
-		++i;
-	}
-	return result + word_rank(p, idx, v);
+    const uint64_t* p = this->m_v->data();
+    size_type i = 0;
+    size_type result = 0;
+    size_type word_pos = (idx * this->t_b) >> 6;
+    while (i < word_pos) {
+        result += this->full_word_rank(p, i, v);
+        ++i;
+    }
+    return result + word_rank(p, idx, v);
 }
 
 //! Counts the occurrences of elements smaller or equal to v in the prefix [0..idx-1]
 /*! \param idx Argument for the length of the prefix v[0..idx-1].
-	 *  \param v Argument which value (including smaller values) to count.
-     *  \sa rank
-     */
+ *  \param v Argument which value (including smaller values) to count.
+ *  \sa rank
+ */
 template <uint8_t alphabet_size>
 inline typename rank_support_int_scan<alphabet_size>::size_type
 rank_support_int_scan<alphabet_size>::prefix_rank(const size_type idx, const value_type v) const
 {
-	assert(v < this->t_v);
-	assert(this->m_v != nullptr);
-	assert(idx <= this->m_v->size());
+    assert(v < this->t_v);
+    assert(this->m_v != nullptr);
+    assert(idx <= this->m_v->size());
 
-	if (unlikely(v == this->t_v - 1))
-		return idx;
+    if (unlikely(v == this->t_v - 1))
+        return idx;
 
-	const uint64_t* p	    = this->m_v->data();
-	size_type		word_pos = (idx * this->t_b) >> 6;
-	size_type       i       = 0;
-	size_type		result  = 0;
-	while (i < word_pos) {
-		result += this->full_word_prefix_rank(p, i, v);
-		++i;
-	}
-	return result + this->word_prefix_rank(p, idx, v);
+    const uint64_t* p = this->m_v->data();
+    size_type		word_pos = (idx * this->t_b) >> 6;
+    size_type       i       = 0;
+    size_type		result  = 0;
+    while (i < word_pos) {
+        result += this->full_word_prefix_rank(p, i, v);
+        ++i;
+    }
+    return result + this->word_prefix_rank(p, idx, v);
 }
 
 } // end namespace sds

--- a/include/sdsl/rank_support_int_scan.hpp
+++ b/include/sdsl/rank_support_int_scan.hpp
@@ -25,6 +25,8 @@ namespace sdsl {
 
 template <uint8_t alphabet_size>
 class rank_support_int_scan : public rank_support_int<alphabet_size> {
+private:
+    using base_t = rank_support_int<alphabet_size>;
 public:
     typedef int_vector<> int_vector_type;
     typedef typename rank_support_int<alphabet_size>::size_type size_type;
@@ -69,10 +71,10 @@ rank_support_int_scan<alphabet_size>::rank(const size_type idx, const value_type
     size_type result = 0;
     size_type word_pos = (idx * this->t_b) >> 6;
     while (i < word_pos) {
-        result += this->full_word_rank(p, i, v);
+        result += base_t::full_word_rank(base_t::extract_word(p, i), v);
         ++i;
     }
-    return result + word_rank(p, idx, v);
+    return result + base_t::word_rank(base_t::extract_word(p, idx), idx * this->sigma_bits, v);
 }
 
 //! Counts the occurrences of elements smaller or equal to v in the prefix [0..idx-1]
@@ -92,14 +94,16 @@ rank_support_int_scan<alphabet_size>::prefix_rank(const size_type idx, const val
         return idx;
 
     const uint64_t* p = this->m_v->data();
-    size_type		word_pos = (idx * this->t_b) >> 6;
+    size_type		word_pos = (idx * this->sigma_bits) >> 6;
     size_type       i       = 0;
     size_type		result  = 0;
+
     while (i < word_pos) {
-        result += this->full_word_prefix_rank(p, i, v);
+        result += base_t::full_word_prefix_rank(base_t::extract_word(p, i), v);
         ++i;
     }
-    return result + this->word_prefix_rank(p, idx, v);
+
+    return result + base_t::word_prefix_rank(base_t::extract_word(p, idx), idx * this->sigma_bits, v)[0];
 }
 
 } // end namespace sds

--- a/include/sdsl/rank_support_int_scan.hpp
+++ b/include/sdsl/rank_support_int_scan.hpp
@@ -1,17 +1,19 @@
 // Copyright (c) 2016, the SDSL Project Authors.  All rights reserved.
 // Please see the AUTHORS file for details.  Use of this source code is governed
 // by a BSD license that can be found in the LICENSE file.
-/*! \file rank_support_int_scan.hpp
-    \brief rank_support_int_scan.hpp contains rank_support_int_scan that support a sdsl::int_vector with linear time rank information.
-    \author Christopher Pockrandt
-*/
+/*!\file rank_support_int_scan.hpp
+ * \brief rank_support_int_scan.hpp contains rank_support_int_scan that support a sdsl::int_vector with linear time
+ *        rank information.
+ * \author Christopher Pockrandt
+ */
 #ifndef INCLUDED_SDSL_RANK_SUPPORT_INT_SCAN
 #define INCLUDED_SDSL_RANK_SUPPORT_INT_SCAN
 
-#include "rank_support_int.hpp"
+#include <sdsl/rank_support_int.hpp>
 
 //! Namespace for the succinct data structure library.
-namespace sdsl {
+namespace sdsl
+{
 
 //! A class supporting rank queries in linear time.
 /*! \par Space complexity
@@ -24,30 +26,37 @@ namespace sdsl {
  */
 
 template <uint8_t alphabet_size>
-class rank_support_int_scan : public rank_support_int<alphabet_size> {
-private:
+class rank_support_int_scan : public rank_support_int<alphabet_size>
+{
+  private:
     using base_t = rank_support_int<alphabet_size>;
-public:
+
+  public:
     typedef int_vector<> int_vector_type;
     typedef typename rank_support_int<alphabet_size>::size_type size_type;
     typedef typename rank_support_int<alphabet_size>::value_type value_type;
 
-public:
-    explicit rank_support_int_scan(const int_vector<>* v = nullptr) : rank_support_int<alphabet_size>(v){};
-    rank_support_int_scan(const rank_support_int_scan& rs) = default;
-    rank_support_int_scan(rank_support_int_scan&& rs) = default;
-    rank_support_int_scan& operator=(const rank_support_int_scan& rs) = default;
-    rank_support_int_scan& operator=(rank_support_int_scan&& rs) = default;
+  public:
+    explicit rank_support_int_scan(const int_vector<> * v = nullptr)
+      : rank_support_int<alphabet_size>(v){};
+    rank_support_int_scan(const rank_support_int_scan & rs) = default;
+    rank_support_int_scan(rank_support_int_scan && rs) = default;
+    rank_support_int_scan & operator=(const rank_support_int_scan & rs) = default;
+    rank_support_int_scan & operator=(rank_support_int_scan && rs) = default;
     size_type rank(size_type idx, const value_type v) const;
     size_type operator()(size_type idx, const value_type v) const { return rank(idx, v); };
     size_type prefix_rank(size_type idx, const value_type v) const;
     size_type size() const { return this->m_v->size(); };
-    size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
+    size_type serialize(std::ostream & out, structure_tree_node * v = nullptr, const std::string name = "") const
     {
         return serialize_empty_object(out, v, name, this);
     }
-    void load(std::istream&, const int_vector<>* v = nullptr) { this->m_v = v; this->init(v); }
-    void set_vector(const int_vector<>* v = nullptr) { this->m_v = v; }
+    void load(std::istream &, const int_vector<> * v = nullptr)
+    {
+        this->m_v = v;
+        this->init(v);
+    }
+    void set_vector(const int_vector<> * v = nullptr) { this->m_v = v; }
 };
 
 //! Counts the occurrences of v in the prefix [0..idx-1]
@@ -56,21 +65,22 @@ public:
  *  \sa prefix_rank
  */
 template <uint8_t alphabet_size>
-inline typename rank_support_int_scan<alphabet_size>::size_type
-rank_support_int_scan<alphabet_size>::rank(const size_type idx, const value_type v) const
+inline typename rank_support_int_scan<alphabet_size>::size_type rank_support_int_scan<alphabet_size>::rank(
+                                                  const size_type idx,
+                                                  const value_type v) const
 {
     assert(v < this->t_v);
     assert(this->m_v != nullptr);
     assert(idx <= this->m_v->size());
 
-    if (unlikely(v == 0))
-        return prefix_rank(idx, v);
+    if (unlikely(v == 0)) return prefix_rank(idx, v);
 
-    const uint64_t* p = this->m_v->data();
+    const uint64_t * p = this->m_v->data();
     size_type i = 0;
     size_type result = 0;
     size_type word_pos = (idx * this->t_b) >> 6;
-    while (i < word_pos) {
+    while (i < word_pos)
+    {
         result += base_t::full_word_rank(base_t::extract_word(p, i), v);
         ++i;
     }
@@ -83,22 +93,23 @@ rank_support_int_scan<alphabet_size>::rank(const size_type idx, const value_type
  *  \sa rank
  */
 template <uint8_t alphabet_size>
-inline typename rank_support_int_scan<alphabet_size>::size_type
-rank_support_int_scan<alphabet_size>::prefix_rank(const size_type idx, const value_type v) const
+inline typename rank_support_int_scan<alphabet_size>::size_type rank_support_int_scan<alphabet_size>::prefix_rank(
+                                                  const size_type idx,
+                                                  const value_type v) const
 {
     assert(v < this->t_v);
     assert(this->m_v != nullptr);
     assert(idx <= this->m_v->size());
 
-    if (unlikely(v == this->t_v - 1))
-        return idx;
+    if (unlikely(v == this->t_v - 1)) return idx;
 
-    const uint64_t* p = this->m_v->data();
-    size_type		word_pos = (idx * this->sigma_bits) >> 6;
-    size_type       i       = 0;
-    size_type		result  = 0;
+    const uint64_t * p = this->m_v->data();
+    size_type word_pos = (idx * this->sigma_bits) >> 6;
+    size_type i = 0;
+    size_type result = 0;
 
-    while (i < word_pos) {
+    while (i < word_pos)
+    {
         result += base_t::full_word_prefix_rank(base_t::extract_word(p, i), v);
         ++i;
     }
@@ -106,6 +117,6 @@ rank_support_int_scan<alphabet_size>::prefix_rank(const size_type idx, const val
     return result + base_t::word_prefix_rank(base_t::extract_word(p, idx), idx * this->sigma_bits, v)[0];
 }
 
-} // end namespace sds
+} // namespace sdsl
 
 #endif // end file

--- a/include/sdsl/rank_support_int_scan.hpp
+++ b/include/sdsl/rank_support_int_scan.hpp
@@ -1,0 +1,107 @@
+// Copyright (c) 2016, the SDSL Project Authors.  All rights reserved.
+// Please see the AUTHORS file for details.  Use of this source code is governed
+// by a BSD license that can be found in the LICENSE file.
+/*! \file rank_support_int_scan.hpp
+    \brief rank_support_int_scan.hpp contains rank_support_int_scan that support a sdsl::int_vector with linear time rank information.
+    \author Christopher Pockrandt
+*/
+#ifndef INCLUDED_SDSL_RANK_SUPPORT_INT_SCAN
+#define INCLUDED_SDSL_RANK_SUPPORT_INT_SCAN
+
+#include "rank_support_int.hpp"
+
+//! Namespace for the succinct data structure library.
+namespace sdsl {
+
+//! A class supporting rank queries in linear time.
+/*! \par Space complexity
+ *       Constant.
+ *  \par Time complexity
+ *       Linear in the size of the supported vector.
+ *
+ *  \tparam alphabet_size Size of the alphabet used in the underlying sdsl::int_vector.
+ * @ingroup rank_support_group
+ */
+
+template <uint8_t alphabet_size>
+class rank_support_int_scan : public rank_support_int<alphabet_size> {
+public:
+	typedef int_vector<> int_vector_type;
+    typedef typename rank_support_int<alphabet_size>::size_type size_type;
+    typedef typename rank_support_int<alphabet_size>::value_type value_type;
+
+public:
+	explicit rank_support_int_scan(const int_vector<>* v = nullptr) : rank_support_int<alphabet_size>(v){};
+	rank_support_int_scan(const rank_support_int_scan& rs) = default;
+	rank_support_int_scan(rank_support_int_scan&& rs)	  = default;
+	rank_support_int_scan& operator=(const rank_support_int_scan& rs) = default;
+	rank_support_int_scan& operator=(rank_support_int_scan&& rs) = default;
+	size_type rank(size_type idx, const value_type v) const;
+	size_type operator()(size_type idx, const value_type v) const { return rank(idx, v); };
+	size_type prefix_rank(size_type idx, const value_type v) const;
+	size_type size() const { return this->m_v->size(); };
+	size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
+	{
+		return serialize_empty_object(out, v, name, this);
+	}
+	void load(std::istream&, const int_vector<>* v = nullptr) { this->m_v = v; this->init(v); }
+	void set_vector(const int_vector<>* v = nullptr) { this->m_v = v; }
+};
+
+//! Counts the occurrences of v in the prefix [0..idx-1]
+/*! \param idx Argument for the length of the prefix v[0..idx-1].
+	 *  \param v Argument which value to count.
+     *  \sa prefix_rank
+     */
+template <uint8_t alphabet_size>
+inline typename rank_support_int_scan<alphabet_size>::size_type
+rank_support_int_scan<alphabet_size>::rank(const size_type idx, const value_type v) const
+{
+	assert(v < this->t_v);
+	assert(this->m_v != nullptr);
+	assert(idx <= this->m_v->size());
+
+	if (unlikely(v == 0))
+		return prefix_rank(idx, v);
+
+	const uint64_t* p = this->m_v->data();
+	size_type i = 0;
+	size_type result = 0;
+	size_type word_pos = (idx * this->t_b) >> 6;
+	while (i < word_pos) {
+		result += this->full_word_rank(p, i, v);
+		++i;
+	}
+	return result + word_rank(p, idx, v);
+}
+
+//! Counts the occurrences of elements smaller or equal to v in the prefix [0..idx-1]
+/*! \param idx Argument for the length of the prefix v[0..idx-1].
+	 *  \param v Argument which value (including smaller values) to count.
+     *  \sa rank
+     */
+template <uint8_t alphabet_size>
+inline typename rank_support_int_scan<alphabet_size>::size_type
+rank_support_int_scan<alphabet_size>::prefix_rank(const size_type idx, const value_type v) const
+{
+	assert(v < this->t_v);
+	assert(this->m_v != nullptr);
+	assert(idx <= this->m_v->size());
+
+	if (unlikely(v == this->t_v - 1))
+		return idx;
+
+	const uint64_t* p	    = this->m_v->data();
+	size_type		word_pos = (idx * this->t_b) >> 6;
+	size_type       i       = 0;
+	size_type		result  = 0;
+	while (i < word_pos) {
+		result += this->full_word_prefix_rank(p, i, v);
+		++i;
+	}
+	return result + this->word_prefix_rank(p, idx, v);
+}
+
+} // end namespace sds
+
+#endif // end file

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -104,6 +104,7 @@ public:
         return word;
     }
 
+    //!\brief Saves to the stream.
     size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
     {
         structure_tree_node* child = structure_tree::add_child(v, name, sdsl::util::class_name(*this));
@@ -112,17 +113,20 @@ public:
         return written_bytes;
     }
 
+    //!\brief Loads from the stream.
     void load(std::istream& in)
     {
         sdsl::load(word, in);
     }
 
+    //!\brief Saves to the archive.
     template <typename archive_t>
     void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
     {
         ar(CEREAL_NVP(word));
     }
 
+    //!\brief Loads from the archive.
     template <typename archive_t>
     void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
     {
@@ -345,7 +349,7 @@ public:
         return superblocks[to_superblock_position(position)].value_at(position);
     }
 
-    //!\brief Serialises the rank support data structure.
+    //!\brief Saves to the stream.
     size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
     {
         structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
@@ -354,14 +358,14 @@ public:
         return written_bytes;
     }
 
-    //!\brief Loads the rank support data structure from the stream.
+    //!\brief Loads from the stream.
     void load(std::istream& in, const int_vector<>* /*v*/)
     {
         this->m_v = nullptr;
         sdsl::load(superblocks, in);
     }
 
-    //!\brief Serialisation via cereal.
+    //!\brief Saves to the archive.
     template <typename archive_t>
     void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
     {
@@ -369,7 +373,7 @@ public:
         ar(CEREAL_NVP(superblocks));
     }
 
-    //!\brief Serialisation via cereal.
+    //!\brief Loads from the archive.
     template <typename archive_t>
     void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
     {
@@ -512,7 +516,7 @@ struct rank_support_int_v<alphabet_size, words_per_block, blocks_per_superblock>
         return superblock_text[absolute_word_position(bit_position)][position % values_per_word];
     }
 
-    //TODO Write me!
+    //!\brief Saves to the stream.
     size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
     {
         structure_tree_node* child = structure_tree::add_child(v, name, sdsl::util::class_name(*this));
@@ -533,6 +537,7 @@ struct rank_support_int_v<alphabet_size, words_per_block, blocks_per_superblock>
         return written_bytes;
     }
 
+    //!\brief Loads from the stream.
     void load(std::istream& in)
     {
         size_type array_size;
@@ -552,6 +557,7 @@ struct rank_support_int_v<alphabet_size, words_per_block, blocks_per_superblock>
             sdsl::load(superblock_text[idx], in);
     }
 
+    //!\brief Saves to the archive.
     template <typename archive_t>
     void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
     {
@@ -560,6 +566,7 @@ struct rank_support_int_v<alphabet_size, words_per_block, blocks_per_superblock>
         ar(CEREAL_NVP(superblock_text));
     }
 
+    //!\brief Loads from the archive.
     template <typename archive_t>
     void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
     {
@@ -569,7 +576,6 @@ struct rank_support_int_v<alphabet_size, words_per_block, blocks_per_superblock>
     }
 
 private:
-
     //!\brief Maps the given position to the block position inside of the superblock.
     static constexpr size_type block_position_in_superblock(size_t const position) noexcept
     { // if constexpr (blocks_per_superblock power of 2)

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -226,7 +226,7 @@ public:
                 // Get the prefix ranks for the current word for each letter and store them in the respective block
                 for (size_t letter_rank = 0; letter_rank < effective_alphabet_size; ++letter_rank, ++block_it)
                 {
-                    buf_blocks[letter_rank] += this->full_word_prefix_rank2(*text_it, letter_rank);
+                    buf_blocks[letter_rank] += this->full_word_prefix_rank(*text_it, letter_rank);
                     *block_it = buf_blocks[letter_rank];
                 }
             }
@@ -235,7 +235,7 @@ public:
             if (word_id < word_count)
             {
                 for (uint64_t letter = 0; letter < effective_alphabet_size; ++letter)
-                    buf_blocks[letter] += this->full_word_prefix_rank2(*text_it, letter);
+                    buf_blocks[letter] += this->full_word_prefix_rank(*text_it, letter);
 
                 ++word_id;
             }
@@ -500,7 +500,7 @@ private:
     static constexpr auto word_prefix_rank(const uint64_t word, const uint64_t bit_pos, const value_type v)
         -> typename std::enable_if<compute_prefix_delta, size_type>::type
     {
-        auto && prefix_rank = base_t::word_prefix_rank2(word, bit_pos, v - 1, v);
+        auto && prefix_rank = base_t::word_prefix_rank(word, bit_pos, v - 1, v);
         return prefix_rank[1] - prefix_rank[0];
     }
 
@@ -509,7 +509,7 @@ private:
     static constexpr auto word_prefix_rank(const uint64_t word, const uint64_t bit_pos, const value_type v)
         -> typename std::enable_if<!compute_prefix_delta, size_type>::type
     {
-        return base_t::word_prefix_rank2(word, bit_pos, v)[0];
+        return base_t::word_prefix_rank(word, bit_pos, v)[0];
     }
 
     //TODO Write me!

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -2,9 +2,9 @@
 // Please see the AUTHORS file for details.  Use of this source code is governed
 // by a BSD license that can be found in the LICENSE file.
 /*! \file rank_support_int_v.hpp
-    \brief rank_support_int_v.hpp contains rank_support_int_v.
-	\author Christopher Pockrandt
-*/
+ *  \brief rank_support_int_v.hpp contains rank_support_int_v.
+ *  \author Christopher Pockrandt
+ */
 #ifndef INCLUDED_SDSL_RANK_SUPPORT_INT_V
 #define INCLUDED_SDSL_RANK_SUPPORT_INT_V
 
@@ -32,69 +32,69 @@ namespace sdsl {
 template <uint8_t alphabet_size, uint8_t words_per_block = 1, uint8_t blocks_per_superblock = 4>
 class rank_support_int_v : public rank_support_int<alphabet_size> {
 public:
-	typedef int_vector<> int_vector_type;
-	typedef typename rank_support_int<alphabet_size>::size_type size_type;
-	typedef typename rank_support_int<alphabet_size>::value_type value_type;
+    typedef int_vector<> int_vector_type;
+    typedef typename rank_support_int<alphabet_size>::size_type size_type;
+    typedef typename rank_support_int<alphabet_size>::value_type value_type;
 
 private:
-	int_vector<0> m_block;
-	int_vector<64> m_superblock; // TODO: set width (at runtime). benchmark space consumption and running time
+    int_vector<0> m_block;
+    int_vector<64> m_superblock; // TODO: set width (at runtime). benchmark space consumption and running time
 
-	static constexpr uint64_t values_per_word{static_cast<uint64_t>(64) / rank_support_int<alphabet_size>::t_b};
-	static constexpr uint32_t values_per_block{words_per_block * values_per_word};
+    static constexpr uint64_t values_per_word{static_cast<uint64_t>(64) / rank_support_int<alphabet_size>::t_b};
+    static constexpr uint32_t values_per_block{words_per_block * values_per_word};
 
 public:
-	explicit rank_support_int_v(const int_vector<>* v = nullptr) : rank_support_int<alphabet_size>(v)
-	{
-	    static_assert(blocks_per_superblock > 1, "There must be at least two blocks per superblock!");
-		constexpr uint8_t t_v_decr{this->t_v - 1};
+    explicit rank_support_int_v(const int_vector<>* v = nullptr) : rank_support_int<alphabet_size>(v)
+    {
+        static_assert(blocks_per_superblock > 1, "There must be at least two blocks per superblock!");
+        constexpr uint8_t t_v_decr{this->t_v - 1};
 
-		if (v == nullptr)
-		{
-			return;
-		}
-		else if (v->empty())
-		{
-			m_block.resize(t_v_decr, 0);
-			m_superblock.resize(t_v_decr, 0);
-			return;
-		}
+        if (v == nullptr)
+        {
+            return;
+        }
+        else if (v->empty())
+        {
+            m_block.resize(t_v_decr, 0);
+            m_superblock.resize(t_v_decr, 0);
+            return;
+        }
 
-		constexpr uint64_t words_per_superblock{words_per_block * blocks_per_superblock};
-		constexpr uint64_t values_per_superblock{blocks_per_superblock * values_per_block};
-		constexpr uint64_t new_width{ceil_log2(values_per_superblock)};
-		m_block.width(new_width);
+        constexpr uint64_t words_per_superblock{words_per_block * blocks_per_superblock};
+        constexpr uint64_t values_per_superblock{blocks_per_superblock * values_per_block};
+        constexpr uint64_t new_width{ceil_log2(values_per_superblock)};
+        m_block.width(new_width);
 
-		// NOTE: number of elements is artificially increased by one because rank can be called on m_v[size()]
-		uint64_t const word_count = ((this->m_v->size() - 1 + 1) / values_per_word) + 1; // equivalent to ceil(m_v->size() / values_per_word)
-		uint64_t const block_count = ((word_count - 1) / words_per_block) + 1; // equivalent to ceil(word_count / words_per_block)
+        // NOTE: number of elements is artificially increased by one because rank can be called on m_v[size()]
+        uint64_t const word_count = ((this->m_v->size() - 1 + 1) / values_per_word) + 1; // equivalent to ceil(m_v->size() / values_per_word)
+        uint64_t const block_count = ((word_count - 1) / words_per_block) + 1; // equivalent to ceil(word_count / words_per_block)
 
-		// for each superblock we only need `blocks_per_superblock-1` instead of `blocks_per_superblock` blocks.
-		// for the last superblock we can subtract the last unused blocks.
+        // for each superblock we only need `blocks_per_superblock-1` instead of `blocks_per_superblock` blocks.
+        // for the last superblock we can subtract the last unused blocks.
         size_type const blocks_needed = (((block_count - 1) / blocks_per_superblock) + 1) * (blocks_per_superblock - 1)
-									  - ((blocks_per_superblock - (block_count % blocks_per_superblock)) % blocks_per_superblock);
-		size_type const block_size = blocks_needed * t_v_decr;
-		size_type const superblock_size = (((word_count - 1) / words_per_superblock) + 1) * t_v_decr; // equivalent to ceil(word_count / words_per_superblock) * t_v_decr
-		m_block.resize(block_size);
-		m_superblock.resize(superblock_size);
+                                      - ((blocks_per_superblock - (block_count % blocks_per_superblock)) % blocks_per_superblock);
+        size_type const block_size = blocks_needed * t_v_decr;
+        size_type const superblock_size = (((word_count - 1) / words_per_superblock) + 1) * t_v_decr; // equivalent to ceil(word_count / words_per_superblock) * t_v_decr
+        m_block.resize(block_size);
+        m_superblock.resize(superblock_size);
 
-		uint64_t const * data = this->m_v->data();
-		std::vector<uint64_t> buf_blocks(t_v_decr, 0);
-		std::vector<uint64_t> buf_superblocks(t_v_decr, 0);
+        uint64_t const * data = this->m_v->data();
+        std::vector<uint64_t> buf_blocks(t_v_decr, 0);
+        std::vector<uint64_t> buf_superblocks(t_v_decr, 0);
 
-		for (uint64_t v = 0; v < t_v_decr; ++v)
-			m_superblock[v] = 0;
+        for (uint64_t v = 0; v < t_v_decr; ++v)
+            m_superblock[v] = 0;
 
-		// Precompute blocks and superblocks
-		// NOTE: divisors in modulo operations are constexpr and hence are expected to be cheap
-		for (uint64_t word_id = 0, block_id = 0, superblock_id = t_v_decr; word_id < word_count; ++word_id)
-		{
-			for (uint64_t v = 0; v < t_v_decr; ++v)
-				buf_blocks[v] += this->full_word_prefix_rank(data, word_id, v);
+        // Precompute blocks and superblocks
+        // NOTE: divisors in modulo operations are constexpr and hence are expected to be cheap
+        for (uint64_t word_id = 0, block_id = 0, superblock_id = t_v_decr; word_id < word_count; ++word_id)
+        {
+            for (uint64_t v = 0; v < t_v_decr; ++v)
+                buf_blocks[v] += this->full_word_prefix_rank(data, word_id, v);
 
-			// counted the values in the last word of the current block
-			if (word_id % words_per_block == (words_per_block - 1))
-			{
+            // counted the values in the last word of the current block
+            if (word_id % words_per_block == (words_per_block - 1))
+            {
                 if (word_id % words_per_superblock != (words_per_superblock - 1))
                 {
                     if (block_id < m_block.size()) // TODO: rewrite for loop to eliminate need for if clause here
@@ -117,80 +117,80 @@ public:
                     }
                     superblock_id += t_v_decr;
                 }
-			}
-		}
+            }
+        }
 
         // std::cout << "\nBlocks:\n";
         // for (uint64_t i = 0; i < m_block.size(); i += t_v_decr)
-		// {
-		// 	for (uint64_t v = 0; v < t_v_decr; ++v)
-	    //         std::cout << (unsigned)m_block[i + v] << ' ';
+        // {
+        // 	for (uint64_t v = 0; v < t_v_decr; ++v)
+        //         std::cout << (unsigned)m_block[i + v] << ' ';
         //     std::cout << "| ";
-		// }
+        // }
         // std::cout << "\nSuperBlocks:\n";
         // for (uint64_t i = 0; i < m_superblock.size(); i += t_v_decr)
-		// {
-		// 	for (uint64_t v = 0; v < t_v_decr; ++v)
+        // {
+        // 	for (uint64_t v = 0; v < t_v_decr; ++v)
         //     	std::cout << (unsigned)m_superblock[i + v] << ' ';
         //     std::cout << "| ";
-		// }
+        // }
         // std::cout << "\n\n";
-	}
+    }
 
-	rank_support_int_v(const rank_support_int_v&) = default;
-	rank_support_int_v(rank_support_int_v&&)	  = default;
-	rank_support_int_v& operator=(const rank_support_int_v&) = default;
-	rank_support_int_v& operator=(rank_support_int_v&&) = default;
+    rank_support_int_v(const rank_support_int_v&) = default;
+    rank_support_int_v(rank_support_int_v&&) = default;
+    rank_support_int_v& operator=(const rank_support_int_v&) = default;
+    rank_support_int_v& operator=(rank_support_int_v&&) = default;
 
-	//! Counts the occurrences of v in the prefix [0..idx-1]
-	/*! \param idx Argument for the length of the prefix v[0..idx-1].
-		 *  \param v Argument which value to count.
-	     *  \sa prefix_rank
-	     */
-	size_type rank(const size_type idx, const value_type v) const
-	{
-		assert(this->m_v != nullptr);
-		assert(idx <= this->m_v->size());
+    //! Counts the occurrences of v in the prefix [0..idx-1]
+    /*! \param idx Argument for the length of the prefix v[0..idx-1].
+     *  \param v Argument which value to count.
+     *  \sa prefix_rank
+     */
+    size_type rank(const size_type idx, const value_type v) const
+    {
+        assert(this->m_v != nullptr);
+        assert(idx <= this->m_v->size());
 
-		if (unlikely(v == 0))
-			return prefix_rank(idx, v);
+        if (unlikely(v == 0))
+            return prefix_rank(idx, v);
 
-		// TODO: optimize this (and benchmark)
-		return prefix_rank(idx, v) - prefix_rank(idx, v - 1);
-	}
+        // TODO: optimize this (and benchmark)
+        return prefix_rank(idx, v) - prefix_rank(idx, v - 1);
+    }
 
-	//! Alias for rank(idx, v)
-	inline size_type operator()(const size_type idx, const value_type v) const { return rank(idx, v); }
+    //! Alias for rank(idx, v)
+    inline size_type operator()(const size_type idx, const value_type v) const { return rank(idx, v); }
 
-	//! Counts the occurrences of elements smaller or equal to v in the prefix [0..idx-1]
-	/*! \param idx Argument for the length of the prefix v[0..idx-1].
-		 *  \param v Argument which value (including smaller values) to count.
-	     *  \sa rank
-	     */
-	size_type prefix_rank(const size_type idx, const value_type v) const
-	{
-		assert(this->m_v != nullptr);
-		assert(idx <= this->m_v->size());
+    //! Counts the occurrences of elements smaller or equal to v in the prefix [0..idx-1]
+    /*! \param idx Argument for the length of the prefix v[0..idx-1].
+     *  \param v Argument which value (including smaller values) to count.
+     *  \sa rank
+     */
+    size_type prefix_rank(const size_type idx, const value_type v) const
+    {
+        assert(this->m_v != nullptr);
+        assert(idx <= this->m_v->size());
         assert(v <= this->t_v);
 
-		if (unlikely(v == this->t_v - 1))
-			return idx;
+        if (unlikely(v == this->t_v - 1))
+            return idx;
 
-		constexpr uint8_t t_v_decr{this->t_v - 1};
+        constexpr uint8_t t_v_decr{this->t_v - 1};
 
-		size_type const block_id{idx / values_per_block};
-		size_type const superblock_id{block_id / blocks_per_superblock};
+        size_type const block_id{idx / values_per_block};
+        size_type const superblock_id{block_id / blocks_per_superblock};
         size_type const block_id_in_superblock{block_id % blocks_per_superblock};
 
-		// retrieve superblock value
+        // retrieve superblock value
         size_type res = m_superblock[t_v_decr * superblock_id + v];
 
-		// retrieve block value
+        // retrieve block value
         if (block_id_in_superblock > 0)
             res += m_block[t_v_decr * superblock_id * (blocks_per_superblock - 1) + (block_id_in_superblock - 1)  * t_v_decr + v];
 
-		// compute in-block queries for all words before the in-block queries
-		// this only applies when multiple words are in one block
+        // compute in-block queries for all words before the in-block queries
+        // this only applies when multiple words are in one block
         if (words_per_block > 1)
         {
             size_type const word_id{idx / values_per_word};
@@ -202,52 +202,52 @@ public:
             }
         }
 
-		// compute in-block query
-		if (idx % values_per_block != 0)
-			res += this->word_prefix_rank(this->m_v->data(), idx, v);
+        // compute in-block query
+        if (idx % values_per_block != 0)
+            res += this->word_prefix_rank(this->m_v->data(), idx, v);
 
-		return res;
-	}
+        return res;
+    }
 
-	size_type size() const { return this->m_v->size(); }
+    size_type size() const { return this->m_v->size(); }
 
-	size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
-	{
-		structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
-		size_type written_bytes = 0;
-		written_bytes += m_block.serialize(out, child, "prefix_block_counts");
-		written_bytes += m_superblock.serialize(out, child, "prefix_superblock_counts");
-		structure_tree::add_size(child, written_bytes);
-		return written_bytes;
-	}
+    size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
+    {
+        structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
+        size_type written_bytes = 0;
+        written_bytes += m_block.serialize(out, child, "prefix_block_counts");
+        written_bytes += m_superblock.serialize(out, child, "prefix_superblock_counts");
+        structure_tree::add_size(child, written_bytes);
+        return written_bytes;
+    }
 
-	void load(std::istream& in, const int_vector<>* v = nullptr)
-	{
-		this->m_v = v;
-		m_block.load(in);
-		m_superblock.load(in);
-		this->init(v);
-	}
+    void load(std::istream& in, const int_vector<>* v = nullptr)
+    {
+        this->m_v = v;
+        m_block.load(in);
+        m_superblock.load(in);
+        this->init(v);
+    }
 
-	template <typename archive_t>
-	void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
-	{
-		ar(CEREAL_NVP(m_block));
-		ar(CEREAL_NVP(m_superblock));
-	}
+    template <typename archive_t>
+    void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
+    {
+        ar(CEREAL_NVP(m_block));
+        ar(CEREAL_NVP(m_superblock));
+    }
 
-	template <typename archive_t>
-	void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
-	{
-		ar(CEREAL_NVP(m_block));
-		ar(CEREAL_NVP(m_superblock));
-	}
+    template <typename archive_t>
+    void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
+    {
+        ar(CEREAL_NVP(m_block));
+        ar(CEREAL_NVP(m_superblock));
+    }
 
-	void set_vector(const int_vector<>* v = nullptr)
-	{
-		this->m_v = v;
-		this->init(v);
-	}
+    void set_vector(const int_vector<>* v = nullptr)
+    {
+        this->m_v = v;
+        this->init(v);
+    }
 };
 
 } // end namespace sdsl

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -256,7 +256,7 @@ public:
                 // Get the prefix ranks for the current word for each letter and store them in the respective block
                 for (size_t letter_rank = 0; letter_rank < effective_alphabet_size; ++letter_rank, ++block_it)
                 {
-                    buf_blocks[letter_rank] += this->full_word_prefix_rank(*text_it, letter_rank);
+                    buf_blocks[letter_rank] += base_t::full_word_prefix_rank(*text_it, letter_rank);
                     *block_it = buf_blocks[letter_rank];
                 }
             }
@@ -265,7 +265,7 @@ public:
             if (word_id < word_count)
             {
                 for (uint64_t letter = 0; letter < effective_alphabet_size; ++letter)
-                    buf_blocks[letter] += this->full_word_prefix_rank(*text_it, letter);
+                    buf_blocks[letter] += base_t::full_word_prefix_rank(*text_it, letter);
 
                 ++word_id;
             }
@@ -310,10 +310,10 @@ public:
      */
     size_type prefix_rank(const size_type position, const value_type v) const
     {
-        assert(position <= this->m_v->size());
-        assert(v <= this->sigma);
+        assert(position <= text_size);
+        assert(v <= sigma);
 
-        if (unlikely(v == this->sigma - 1))
+        if (unlikely(v == sigma - 1))
             return position;
 
         return prefix_rank_impl<false>(position, v);
@@ -400,9 +400,7 @@ private:
     template <bool compute_prefix_delta>
     size_type prefix_rank_impl(size_type const position, const value_type v) const
     {
-        assert(position <= this->m_v->size());
-        assert(v < this->sigma); // v cannot have rank sigma - 1
-        assert(v > 0); // v cannot have rank 0
+        assert(position <= text_size);
 
         superblock_entry const & entry = superblocks[to_superblock_position(position)];
         return entry.template superblock_rank<compute_prefix_delta>(v) +

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -107,7 +107,7 @@ class bit_compressed_word
     size_type serialize(std::ostream & out, structure_tree_node * v = nullptr, const std::string name = "") const
     {
         structure_tree_node * child = structure_tree::add_child(v, name, sdsl::util::class_name(*this));
-        size_type written_bytes = sdsl::serialize(word, out, v, "compressed_word");
+        size_type written_bytes = sdsl::serialize(word, out, child, "compressed_word");
         structure_tree::add_size(child, written_bytes);
         return written_bytes;
     }
@@ -349,7 +349,8 @@ class rank_support_int_v : public rank_support_int<alphabet_size>
     size_type serialize(std::ostream & out, structure_tree_node * v = nullptr, const std::string name = "") const
     {
         structure_tree_node * child = structure_tree::add_child(v, name, util::class_name(*this));
-        size_type written_bytes = sdsl::serialize(superblocks, out, v, "superblocks_vector");
+        size_type written_bytes = sdsl::serialize(superblocks, out, child, "superblocks_vector");
+        written_bytes += write_member(text_size, out, child, "text_size");
         structure_tree::add_size(child, written_bytes);
         return written_bytes;
     }
@@ -517,13 +518,13 @@ struct rank_support_int_v<alphabet_size, words_per_block, blocks_per_superblock>
     {
         structure_tree_node * child = structure_tree::add_child(v, name, sdsl::util::class_name(*this));
         size_type written_bytes = 0;
-        written_bytes += sdsl::serialize(superblocks.size(), out, v, "prefix_superblock_counts");
+        written_bytes += sdsl::serialize(superblocks.size(), out, child, "prefix_superblock_counts");
         for (const auto & x : superblocks) written_bytes += sdsl::serialize(x, out, child, "[]");
 
-        written_bytes += sdsl::serialize(blocks.size(), out, v, "prefix_block_counts");
+        written_bytes += sdsl::serialize(blocks.size(), out, child, "prefix_block_counts");
         for (const auto & x : blocks) written_bytes += sdsl::serialize(x, out, child, "[]");
 
-        written_bytes += sdsl::serialize(superblock_text.size(), out, v, "superblock_text");
+        written_bytes += sdsl::serialize(superblock_text.size(), out, child, "superblock_text");
         for (const auto & x : superblock_text) written_bytes += sdsl::serialize(x, out, child, "[]");
 
         structure_tree::add_size(child, written_bytes);

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -584,13 +584,13 @@ private:
 
     //!\brief Maps a block position to its absolute position within the block array.
     static constexpr size_type absolute_block_position(size_t const block_position) noexcept
-    { // We don't care if it overflows as we protect against it later.
-        return (block_position - 1) * block_offset;
+    {
+        return (block_position + (block_position == 0) - 1) * block_offset;
     }
 
     //!\brief Maps a text position to the respective bit position in the bit vector.
     static constexpr size_type absolute_bit_position(size_t const position) noexcept
-    { // We don't care if it overflows as we protect against it later.
+    {
         return (position % values_per_superblock) * sigma_bits;
     }
 

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -1,0 +1,255 @@
+// Copyright (c) 2016, the SDSL Project Authors.  All rights reserved.
+// Please see the AUTHORS file for details.  Use of this source code is governed
+// by a BSD license that can be found in the LICENSE file.
+/*! \file rank_support_int_v.hpp
+    \brief rank_support_int_v.hpp contains rank_support_int_v.
+	\author Christopher Pockrandt
+*/
+#ifndef INCLUDED_SDSL_RANK_SUPPORT_INT_V
+#define INCLUDED_SDSL_RANK_SUPPORT_INT_V
+
+#include "rank_support_int.hpp"
+
+//! Namespace for the succinct data structure library.
+namespace sdsl {
+
+//! A rank structure proposed by Christopher Pockrandt
+/*!
+ * This data structure is similar to rank data structures on bit vectors.
+ * It supports constant time rank and prefix_rank queries on int vectors.
+ *
+ * \tparam alphabet_size         Size of the alphabet represented in the int_vector, i.e., largest value + 1.
+ * \tparam words_per_block       Words per block (equivalent to the number of popcount operations in the worst-case per rank query).
+ * \tparam blocks_per_superblock Blocks per superblock.
+ *
+ * \par Reference
+ *    Christopher Pockrandt:
+ *    EPR-Dictionaries: A practical and fast data structure for constant time searches in unidirectional and bidirectional FM-indices.
+ *    WEA 2008: 154-168
+ *
+ * @ingroup rank_support_group
+ */
+template <uint8_t alphabet_size, uint8_t words_per_block = 1, uint8_t blocks_per_superblock = 4>
+class rank_support_int_v : public rank_support_int<alphabet_size> {
+public:
+	typedef int_vector<> int_vector_type;
+	typedef typename rank_support_int<alphabet_size>::size_type size_type;
+	typedef typename rank_support_int<alphabet_size>::value_type value_type;
+
+private:
+	int_vector<0> m_block;
+	int_vector<64> m_superblock; // TODO: set width (at runtime). benchmark space consumption and running time
+
+	static constexpr uint64_t values_per_word{static_cast<uint64_t>(64) / rank_support_int<alphabet_size>::t_b};
+	static constexpr uint32_t values_per_block{words_per_block * values_per_word};
+
+public:
+	explicit rank_support_int_v(const int_vector<>* v = nullptr) : rank_support_int<alphabet_size>(v)
+	{
+	    static_assert(blocks_per_superblock > 1, "There must be at least two blocks per superblock!");
+		constexpr uint8_t t_v_decr{this->t_v - 1};
+
+		if (v == nullptr)
+		{
+			return;
+		}
+		else if (v->empty())
+		{
+			m_block.resize(t_v_decr, 0);
+			m_superblock.resize(t_v_decr, 0);
+			return;
+		}
+
+		constexpr uint64_t words_per_superblock{words_per_block * blocks_per_superblock};
+		constexpr uint64_t values_per_superblock{blocks_per_superblock * values_per_block};
+		constexpr uint64_t new_width{ceil_log2(values_per_superblock)};
+		m_block.width(new_width);
+
+		// NOTE: number of elements is artificially increased by one because rank can be called on m_v[size()]
+		uint64_t const word_count = ((this->m_v->size() - 1 + 1) / values_per_word) + 1; // equivalent to ceil(m_v->size() / values_per_word)
+		uint64_t const block_count = ((word_count - 1) / words_per_block) + 1; // equivalent to ceil(word_count / words_per_block)
+
+		// for each superblock we only need `blocks_per_superblock-1` instead of `blocks_per_superblock` blocks.
+		// for the last superblock we can subtract the last unused blocks.
+        size_type const blocks_needed = (((block_count - 1) / blocks_per_superblock) + 1) * (blocks_per_superblock - 1)
+									  - ((blocks_per_superblock - (block_count % blocks_per_superblock)) % blocks_per_superblock);
+		size_type const block_size = blocks_needed * t_v_decr;
+		size_type const superblock_size = (((word_count - 1) / words_per_superblock) + 1) * t_v_decr; // equivalent to ceil(word_count / words_per_superblock) * t_v_decr
+		m_block.resize(block_size);
+		m_superblock.resize(superblock_size);
+
+		uint64_t const * data = this->m_v->data();
+		std::vector<uint64_t> buf_blocks(t_v_decr, 0);
+		std::vector<uint64_t> buf_superblocks(t_v_decr, 0);
+
+		for (uint64_t v = 0; v < t_v_decr; ++v)
+			m_superblock[v] = 0;
+
+		// Precompute blocks and superblocks
+		// NOTE: divisors in modulo operations are constexpr and hence are expected to be cheap
+		for (uint64_t word_id = 0, block_id = 0, superblock_id = t_v_decr; word_id < word_count; ++word_id)
+		{
+			for (uint64_t v = 0; v < t_v_decr; ++v)
+				buf_blocks[v] += this->full_word_prefix_rank(data, word_id, v);
+
+			// counted the values in the last word of the current block
+			if (word_id % words_per_block == (words_per_block - 1))
+			{
+                if (word_id % words_per_superblock != (words_per_superblock - 1))
+                {
+                    if (block_id < m_block.size()) // TODO: rewrite for loop to eliminate need for if clause here
+                    {
+                        for (uint64_t v = 0; v < t_v_decr; ++v)
+                            m_block[block_id + v] = buf_blocks[v];
+                        block_id += t_v_decr;
+                    }
+                }
+                else
+                { // don't store block information for the last block in the superblock!
+                    if (superblock_id < m_superblock.size()) // TODO: rewrite for loop to eliminate need for if clause here
+                    {
+                        for (uint64_t v = 0; v < t_v_decr; ++v)
+                        {
+                            buf_superblocks[v] += buf_blocks[v];
+                            m_superblock[superblock_id + v] = buf_superblocks[v];
+                            buf_blocks[v] = 0; // reset blocks
+                        }
+                    }
+                    superblock_id += t_v_decr;
+                }
+			}
+		}
+
+        // std::cout << "\nBlocks:\n";
+        // for (uint64_t i = 0; i < m_block.size(); i += t_v_decr)
+		// {
+		// 	for (uint64_t v = 0; v < t_v_decr; ++v)
+	    //         std::cout << (unsigned)m_block[i + v] << ' ';
+        //     std::cout << "| ";
+		// }
+        // std::cout << "\nSuperBlocks:\n";
+        // for (uint64_t i = 0; i < m_superblock.size(); i += t_v_decr)
+		// {
+		// 	for (uint64_t v = 0; v < t_v_decr; ++v)
+        //     	std::cout << (unsigned)m_superblock[i + v] << ' ';
+        //     std::cout << "| ";
+		// }
+        // std::cout << "\n\n";
+	}
+
+	rank_support_int_v(const rank_support_int_v&) = default;
+	rank_support_int_v(rank_support_int_v&&)	  = default;
+	rank_support_int_v& operator=(const rank_support_int_v&) = default;
+	rank_support_int_v& operator=(rank_support_int_v&&) = default;
+
+	//! Counts the occurrences of v in the prefix [0..idx-1]
+	/*! \param idx Argument for the length of the prefix v[0..idx-1].
+		 *  \param v Argument which value to count.
+	     *  \sa prefix_rank
+	     */
+	size_type rank(const size_type idx, const value_type v) const
+	{
+		assert(this->m_v != nullptr);
+		assert(idx <= this->m_v->size());
+
+		if (unlikely(v == 0))
+			return prefix_rank(idx, v);
+
+		// TODO: optimize this (and benchmark)
+		return prefix_rank(idx, v) - prefix_rank(idx, v - 1);
+	}
+
+	//! Alias for rank(idx, v)
+	inline size_type operator()(const size_type idx, const value_type v) const { return rank(idx, v); }
+
+	//! Counts the occurrences of elements smaller or equal to v in the prefix [0..idx-1]
+	/*! \param idx Argument for the length of the prefix v[0..idx-1].
+		 *  \param v Argument which value (including smaller values) to count.
+	     *  \sa rank
+	     */
+	size_type prefix_rank(const size_type idx, const value_type v) const
+	{
+		assert(this->m_v != nullptr);
+		assert(idx <= this->m_v->size());
+        assert(v <= this->t_v);
+
+		if (unlikely(v == this->t_v - 1))
+			return idx;
+
+		constexpr uint8_t t_v_decr{this->t_v - 1};
+
+		size_type const block_id{idx / values_per_block};
+		size_type const superblock_id{block_id / blocks_per_superblock};
+        size_type const block_id_in_superblock{block_id % blocks_per_superblock};
+
+		// retrieve superblock value
+        size_type res = m_superblock[t_v_decr * superblock_id + v];
+
+		// retrieve block value
+        if (block_id_in_superblock > 0)
+            res += m_block[t_v_decr * superblock_id * (blocks_per_superblock - 1) + (block_id_in_superblock - 1)  * t_v_decr + v];
+
+		// compute in-block queries for all words before the in-block queries
+		// this only applies when multiple words are in one block
+        if (words_per_block > 1)
+        {
+            size_type const word_id{idx / values_per_word};
+            uint64_t w{word_id - (word_id % words_per_block)};
+            while (w < word_id)
+            {
+                res += this->full_word_prefix_rank(this->m_v->data(), w, v);
+                ++w;
+            }
+        }
+
+		// compute in-block query
+		if (idx % values_per_block != 0)
+			res += this->word_prefix_rank(this->m_v->data(), idx, v);
+
+		return res;
+	}
+
+	size_type size() const { return this->m_v->size(); }
+
+	size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
+	{
+		structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
+		size_type written_bytes = 0;
+		written_bytes += m_block.serialize(out, child, "prefix_block_counts");
+		written_bytes += m_superblock.serialize(out, child, "prefix_superblock_counts");
+		structure_tree::add_size(child, written_bytes);
+		return written_bytes;
+	}
+
+	void load(std::istream& in, const int_vector<>* v = nullptr)
+	{
+		this->m_v = v;
+		m_block.load(in);
+		m_superblock.load(in);
+		this->init(v);
+	}
+
+	template <typename archive_t>
+	void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
+	{
+		ar(CEREAL_NVP(m_block));
+		ar(CEREAL_NVP(m_superblock));
+	}
+
+	template <typename archive_t>
+	void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
+	{
+		ar(CEREAL_NVP(m_block));
+		ar(CEREAL_NVP(m_superblock));
+	}
+
+	void set_vector(const int_vector<>* v = nullptr)
+	{
+		this->m_v = v;
+		this->init(v);
+	}
+};
+
+} // end namespace sdsl
+
+#endif // end file

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -360,14 +360,15 @@ class rank_support_int_v : public rank_support_int<alphabet_size>
     {
         this->m_v = nullptr;
         sdsl::load(superblocks, in);
+        read_member(text_size, in);
     }
 
     //!\brief Saves to the archive.
     template <typename archive_t>
     void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
     {
-        (void)ar;
         ar(CEREAL_NVP(superblocks));
+        ar(CEREAL_NVP(text_size));
     }
 
     //!\brief Loads from the archive.
@@ -375,6 +376,7 @@ class rank_support_int_v : public rank_support_int<alphabet_size>
     void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
     {
         ar(CEREAL_NVP(superblocks));
+        ar(CEREAL_NVP(text_size));
     }
 
     //!\brief Does nothing for the rank_support_int structure.

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -1,21 +1,23 @@
 // Copyright (c) 2016, the SDSL Project Authors.  All rights reserved.
 // Please see the AUTHORS file for details.  Use of this source code is governed
 // by a BSD license that can be found in the LICENSE file.
-/*! \file rank_support_int_v.hpp
- *  \brief rank_support_int_v.hpp contains rank_support_int_v.
- *  \author Christopher Pockrandt
- *  \author René Rahn
+/*!\file rank_support_int_v.hpp
+ * \brief rank_support_int_v.hpp contains rank_support_int_v.
+ * \author Christopher Pockrandt
+ * \author René Rahn
  */
 #ifndef INCLUDED_SDSL_RANK_SUPPORT_INT_V
 #define INCLUDED_SDSL_RANK_SUPPORT_INT_V
 
 #include <array>
 
-#include "io.hpp"
-#include "rank_support_int.hpp"
+#include <sdsl/io.hpp>
+#include <sdsl/rank_support_int.hpp>
 
-namespace sdsl{
-namespace detail {
+namespace sdsl
+{
+namespace detail
+{
 
 /*!\brief A bit compressed
  * \tparam value_t The represented value_type.
@@ -29,7 +31,7 @@ namespace detail {
 template <typename value_t, size_t bits_per_value>
 class bit_compressed_word
 {
-private:
+  private:
     static_assert(bits_per_value <= 64, "The maximum bit size is 64 for a value.");
 
     //!\brief The maximal number of values that can be stored in one word.
@@ -40,7 +42,7 @@ private:
     //!\brief The data holder that stores the compressed values.
     uint64_t word{};
 
-public:
+  public:
     //!\brief The size type needed for serialisation.
     using size_type = size_t;
 
@@ -94,30 +96,24 @@ public:
         for (size_t index = 0; it != end; ++it, ++index)
         {
             uint64_t offset = index * bits_per_value;
-            word = (word & ~(bit_mask << offset)) | uint64_t{*it} << offset;
+            word = (word & ~(bit_mask << offset)) | uint64_t{ *it } << offset;
         }
     }
 
     //!\brief Implicitly converts to the word type.
-    constexpr operator uint64_t() const noexcept
-    {
-        return word;
-    }
+    constexpr operator uint64_t() const noexcept { return word; }
 
     //!\brief Saves to the stream.
-    size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
+    size_type serialize(std::ostream & out, structure_tree_node * v = nullptr, const std::string name = "") const
     {
-        structure_tree_node* child = structure_tree::add_child(v, name, sdsl::util::class_name(*this));
+        structure_tree_node * child = structure_tree::add_child(v, name, sdsl::util::class_name(*this));
         size_type written_bytes = sdsl::serialize(word, out, v, "compressed_word");
         structure_tree::add_size(child, written_bytes);
         return written_bytes;
     }
 
     //!\brief Loads from the stream.
-    void load(std::istream& in)
-    {
-        sdsl::load(word, in);
-    }
+    void load(std::istream & in) { sdsl::load(word, in); }
 
     //!\brief Saves to the archive.
     template <typename archive_t>
@@ -137,43 +133,45 @@ public:
 } // namespace sdsl
 
 //! Namespace for the succinct data structure library.
-namespace sdsl {
+namespace sdsl
+{
 
-//! A rank structure proposed by Christopher Pockrandt
-/*!
+/*!\brief A rank structure proposed by Christopher Pockrandt
+ *
  * This data structure is similar to rank data structures on bit vectors.
  * It supports constant time rank and prefix_rank queries on int vectors.
  *
  * \tparam alphabet_size         Size of the alphabet represented in the int_vector, i.e., largest value + 1.
- * \tparam words_per_block       Words per block (equivalent to the number of popcount operations in the worst-case per rank query).
- * \tparam blocks_per_superblock Blocks per superblock.
+ * \tparam words_per_block       Words per block (equivalent to the number of popcount operations in the worst-case per
+ * rank query). \tparam blocks_per_superblock Blocks per superblock.
  *
  * \par Reference
  *    Christopher Pockrandt:
- *    EPR-Dictionaries: A practical and fast data structure for constant time searches in unidirectional and bidirectional FM-indices.
- *    WEA 2008: 154-168
+ *    EPR-Dictionaries: A practical and fast data structure for constant time searches in unidirectional and
+ *                      bidirectional FM-indices. WEA 2008: 154-168
  *
  * @ingroup rank_support_group
  */
 template <uint8_t alphabet_size, uint8_t words_per_block = 1, uint8_t blocks_per_superblock = 4>
-class rank_support_int_v : public rank_support_int<alphabet_size> {
-private:
+class rank_support_int_v : public rank_support_int<alphabet_size>
+{
+  private:
     //!\brief The type of the base class.
     using base_t = rank_support_int<alphabet_size>;
 
     // Import sigma specific constants from base class.
+    using base_t::bits_per_word;
     using base_t::sigma;
     using base_t::sigma_bits;
-    using base_t::bits_per_word;
 
     //!\brief How many values can be stored in one word.
-    static constexpr uint64_t values_per_word{64ULL / sigma_bits};
+    static constexpr uint64_t values_per_word{ 64ULL / sigma_bits };
     //!\brief How many values can be stored in one block.
-    static constexpr uint64_t values_per_block{words_per_block * values_per_word};
+    static constexpr uint64_t values_per_block{ words_per_block * values_per_word };
     //!\brief How many values can be stored in one superblock.
-    static constexpr uint64_t values_per_superblock{blocks_per_superblock * values_per_block};
+    static constexpr uint64_t values_per_superblock{ blocks_per_superblock * values_per_block };
     //!\brief How many words can be stored in one superblock.
-    static constexpr uint64_t words_per_superblock{words_per_block * blocks_per_superblock};
+    static constexpr uint64_t words_per_superblock{ words_per_block * blocks_per_superblock };
     //!\brief The effective alphabet size needed to compute the prefix ranks.
     static constexpr uint64_t effective_alphabet_size = alphabet_size - 1;
 
@@ -184,7 +182,7 @@ private:
     //!\brief The size of the original text.
     typename base_t::size_type text_size{};
 
-public:
+  public:
     //!\brief The size type.
     using typename base_t::size_type;
     //!\brief The value type.
@@ -199,12 +197,12 @@ public:
      * prefix rank for a given symbol and prefix length. Accordingly, the pointer to the text of the base class will
      * always be a nullptr.
      */
-    explicit rank_support_int_v(const int_vector<> * text_ptr = nullptr) : rank_support_int<alphabet_size>(nullptr)
+    explicit rank_support_int_v(const int_vector<> * text_ptr = nullptr)
+      : rank_support_int<alphabet_size>(nullptr)
     {
         static_assert(blocks_per_superblock > 1, "There must be at least two blocks per superblock!");
 
-        if (text_ptr == nullptr || text_ptr->empty())
-            return;
+        if (text_ptr == nullptr || text_ptr->empty()) return;
 
         text_size = text_ptr->size();
 
@@ -221,7 +219,7 @@ public:
 
         // Iterate over the superblock entries and initialise them.
         auto text_slice_it = text_ptr->begin();
-        uint64_t word_id = 0;  // We basically iterate over all words of the underlying text.
+        uint64_t word_id = 0; // We basically iterate over all words of the underlying text.
         for (auto entry_it = superblocks.begin(); entry_it != superblocks.end(); ++entry_it)
         {
             // First initialise the superblock text.
@@ -232,17 +230,17 @@ public:
                                                 std::min<size_t>(std::distance(text_slice_it, text_ptr->end()),
                                                                  values_per_word));
                 compressed_word.assign(text_slice_it, text_slice_end); // Assign text slice to compressed word.
-                text_slice_it = text_slice_end; // Set to next text slice begin.
+                text_slice_it = text_slice_end;                        // Set to next text slice begin.
             }
 
             // Second initialise the superblock counts.
             // The rank values are stored for every symbol of the alphabet in consecutive order.
             // The last symbol can be ignored since it's prefix sum will always be same as the prefix length.
-            auto superblock_it = entry_it->superblocks.begin();  // Store the begin of the super block in the node.
+            auto superblock_it = entry_it->superblocks.begin(); // Store the begin of the super block in the node.
             for (size_t letter_rank = 0; letter_rank < effective_alphabet_size; ++letter_rank, ++superblock_it)
             {
                 buf_superblocks[letter_rank] += buf_blocks[letter_rank]; // Update sum with previous superblock
-                *superblock_it = buf_superblocks[letter_rank]; // Store the counts.
+                *superblock_it = buf_superblocks[letter_rank];           // Store the counts.
                 buf_blocks[letter_rank] = 0; // Reset the block counts for the next superblock.
             }
 
@@ -253,8 +251,7 @@ public:
             // next block at offset `i * effective_alphabet_size`, where `i` is the current block id.
             // TODO: Make the implementation safe for multiple words per block
             auto text_it = entry_it->superblock_text.begin();
-            for (auto block_it = entry_it->blocks.begin();
-                 word_id < word_count && block_it != entry_it->blocks.end();
+            for (auto block_it = entry_it->blocks.begin(); word_id < word_count && block_it != entry_it->blocks.end();
                  ++word_id, ++text_it)
             {
                 // Get the prefix ranks for the current word for each letter and store them in the respective block
@@ -277,13 +274,13 @@ public:
     }
 
     //!\brief Defaulted copy constructor.
-    rank_support_int_v(const rank_support_int_v&) = default;
+    rank_support_int_v(const rank_support_int_v &) = default;
     //!\brief Defaulted move constructor.
-    rank_support_int_v(rank_support_int_v&&) = default;
+    rank_support_int_v(rank_support_int_v &&) = default;
     //!\brief Defaulted copy assignment.
-    rank_support_int_v& operator=(const rank_support_int_v&) = default;
+    rank_support_int_v & operator=(const rank_support_int_v &) = default;
     //!\brief Defaulted move assignment.
-    rank_support_int_v& operator=(rank_support_int_v&&) = default;
+    rank_support_int_v & operator=(rank_support_int_v &&) = default;
     //!\brief Defaulted destructor.
     ~rank_support_int_v() = default;
 
@@ -297,8 +294,8 @@ public:
     {
         switch (v)
         {
-            case 0 : return prefix_rank_impl<false>(position, v);
-            case sigma - 1 : return position - prefix_rank_impl<false>(position, v - 1);
+            case 0: return prefix_rank_impl<false>(position, v);
+            case sigma - 1: return position - prefix_rank_impl<false>(position, v - 1);
             default: return prefix_rank_impl<true>(position, v);
         }
     }
@@ -317,8 +314,7 @@ public:
         assert(position <= text_size);
         assert(v <= sigma);
 
-        if (unlikely(v == sigma - 1))
-            return position;
+        if (unlikely(v == sigma - 1)) return position;
 
         return prefix_rank_impl<false>(position, v);
         // TODO: Enable me!
@@ -350,16 +346,16 @@ public:
     }
 
     //!\brief Saves to the stream.
-    size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
+    size_type serialize(std::ostream & out, structure_tree_node * v = nullptr, const std::string name = "") const
     {
-        structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
+        structure_tree_node * child = structure_tree::add_child(v, name, util::class_name(*this));
         size_type written_bytes = sdsl::serialize(superblocks, out, v, "superblocks_vector");
         structure_tree::add_size(child, written_bytes);
         return written_bytes;
     }
 
     //!\brief Loads from the stream.
-    void load(std::istream& in, const int_vector<>* /*v*/)
+    void load(std::istream & in, const int_vector<> * /*v*/)
     {
         this->m_v = nullptr;
         sdsl::load(superblocks, in);
@@ -369,7 +365,7 @@ public:
     template <typename archive_t>
     void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
     {
-        (void) ar;
+        (void)ar;
         ar(CEREAL_NVP(superblocks));
     }
 
@@ -381,12 +377,12 @@ public:
     }
 
     //!\brief Does nothing for the rank_support_int structure.
-    void set_vector(const int_vector<>* /*other_text*/ ){} // TODO: Check where this interface is needed, since it is dangerous?
-    // I would be able to reset the text without recomputing the rank support structure which is in general a
-    // bad design.
+    void set_vector(const int_vector<> * /*other_text*/) {
+    } // TODO: Check where this interface is needed, since it is dangerous?
+      // I would be able to reset the text without recomputing the rank support structure which is in general a
+      // bad design.
 
-private:
-
+  private:
     /*!\brief Determines the superblock position covering the given text position.
      * \param[in] position The given text position.
      * \returns The position of the superblock that covers the given text position.
@@ -447,9 +443,7 @@ struct rank_support_int_v<alphabet_size, words_per_block, blocks_per_superblock>
     //!\brief The smallest integer type needed to store the block ranks.
     using block_value_type = std::conditional_t<bits_per_block_value <= 8,
                                                 uint8_t,
-                                                std::conditional_t<bits_per_block_value <= 16,
-                                                                   uint16_t,
-                                                                   uint32_t>>;
+                                                std::conditional_t<bits_per_block_value <= 16, uint16_t, uint32_t>>;
 
     //!\brief The array storing the super block values.
     std::array<uint64_t, (alphabet_size - 1)> superblocks;
@@ -519,44 +513,38 @@ struct rank_support_int_v<alphabet_size, words_per_block, blocks_per_superblock>
     }
 
     //!\brief Saves to the stream.
-    size_type serialize(std::ostream& out, structure_tree_node* v = nullptr, const std::string name = "") const
+    size_type serialize(std::ostream & out, structure_tree_node * v = nullptr, const std::string name = "") const
     {
-        structure_tree_node* child = structure_tree::add_child(v, name, sdsl::util::class_name(*this));
+        structure_tree_node * child = structure_tree::add_child(v, name, sdsl::util::class_name(*this));
         size_type written_bytes = 0;
         written_bytes += sdsl::serialize(superblocks.size(), out, v, "prefix_superblock_counts");
-        for (const auto & x : superblocks)
-            written_bytes += sdsl::serialize(x, out, child, "[]");
+        for (const auto & x : superblocks) written_bytes += sdsl::serialize(x, out, child, "[]");
 
         written_bytes += sdsl::serialize(blocks.size(), out, v, "prefix_block_counts");
-        for (const auto & x : blocks)
-            written_bytes += sdsl::serialize(x, out, child, "[]");
+        for (const auto & x : blocks) written_bytes += sdsl::serialize(x, out, child, "[]");
 
         written_bytes += sdsl::serialize(superblock_text.size(), out, v, "superblock_text");
-        for (const auto & x : superblock_text)
-            written_bytes += sdsl::serialize(x, out, child, "[]");
+        for (const auto & x : superblock_text) written_bytes += sdsl::serialize(x, out, child, "[]");
 
         structure_tree::add_size(child, written_bytes);
         return written_bytes;
     }
 
     //!\brief Loads from the stream.
-    void load(std::istream& in)
+    void load(std::istream & in)
     {
         size_type array_size;
         sdsl::load(array_size, in);
         assert(array_size == superblocks.size());
-        for (size_type idx = 0; idx < array_size; ++idx)
-            sdsl::load(superblocks[idx], in);
+        for (size_type idx = 0; idx < array_size; ++idx) sdsl::load(superblocks[idx], in);
 
         sdsl::load(array_size, in);
         assert(array_size == blocks.size());
-        for (size_type idx = 0; idx < array_size; ++idx)
-            sdsl::load(blocks[idx], in);
+        for (size_type idx = 0; idx < array_size; ++idx) sdsl::load(blocks[idx], in);
 
         sdsl::load(array_size, in);
         assert(array_size == superblock_text.size());
-        for (size_type idx = 0; idx < array_size; ++idx)
-            sdsl::load(superblock_text[idx], in);
+        for (size_type idx = 0; idx < array_size; ++idx) sdsl::load(superblock_text[idx], in);
     }
 
     //!\brief Saves to the archive.
@@ -577,7 +565,7 @@ struct rank_support_int_v<alphabet_size, words_per_block, blocks_per_superblock>
         ar(CEREAL_NVP(superblock_text));
     }
 
-private:
+  private:
     //!\brief Maps the given position to the block position inside of the superblock.
     static constexpr size_type block_position_in_superblock(size_t const position) noexcept
     { // if constexpr (blocks_per_superblock power of 2)
@@ -604,8 +592,8 @@ private:
 
     //!\brief Computes the in-block rank for the delta prefix.
     template <bool compute_prefix_delta>
-    static constexpr auto word_prefix_rank(const uint64_t word, const uint64_t bit_pos, const value_type v)
-        -> typename std::enable_if<compute_prefix_delta, size_type>::type
+    static constexpr auto word_prefix_rank(const uint64_t word, const uint64_t bit_pos, const value_type v) ->
+                                                      typename std::enable_if<compute_prefix_delta, size_type>::type
     {
         auto && prefix_rank = base_t::word_prefix_rank(word, bit_pos, v - 1, v);
         return prefix_rank[1] - prefix_rank[0];
@@ -613,8 +601,8 @@ private:
 
     //!\brief Computes the in-block rank for the non-delta prefix.
     template <bool compute_prefix_delta>
-    static constexpr auto word_prefix_rank(const uint64_t word, const uint64_t bit_pos, const value_type v)
-        -> typename std::enable_if<!compute_prefix_delta, size_type>::type
+    static constexpr auto word_prefix_rank(const uint64_t word, const uint64_t bit_pos, const value_type v) ->
+                                                      typename std::enable_if<!compute_prefix_delta, size_type>::type
     {
         return base_t::word_prefix_rank(word, bit_pos, v)[0];
     }

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -363,6 +363,18 @@ class rank_support_int_v : public rank_support_int<alphabet_size>
         read_member(text_size, in);
     }
 
+    //! Equality operator.
+    friend bool operator==(rank_support_int_v const & lhs, rank_support_int_v const & rhs) noexcept
+    {
+        return (lhs.superblocks == rhs.superblocks) && (lhs.text_size == rhs.text_size);
+    }
+
+    //! Inequality operator.
+    friend bool operator!=(rank_support_int_v const & lhs, rank_support_int_v const & rhs) noexcept
+    {
+        return !(lhs == rhs);
+    }
+
     //!\brief Saves to the archive.
     template <typename archive_t>
     void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
@@ -548,6 +560,19 @@ struct rank_support_int_v<alphabet_size, words_per_block, blocks_per_superblock>
         sdsl::load(array_size, in);
         assert(array_size == superblock_text.size());
         for (size_type idx = 0; idx < array_size; ++idx) sdsl::load(superblock_text[idx], in);
+    }
+
+    //! Equality operator.
+    friend bool operator==(superblock_entry const & lhs, superblock_entry const & rhs) noexcept
+    {
+        return (lhs.superblocks == rhs.superblocks) && (lhs.blocks == rhs.blocks) &&
+               (lhs.superblock_text == rhs.superblock_text);
+    }
+
+    //! Inequality operator.
+    friend bool operator!=(superblock_entry const & lhs, superblock_entry const & rhs) noexcept
+    {
+        return !(lhs == rhs);
     }
 
     //!\brief Saves to the archive.

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -91,7 +91,7 @@ class bit_compressed_word
     template <typename it_t>
     constexpr void assign(it_t it, it_t end) noexcept
     {
-        assert(std::distance(it, end) <= max_size);
+        assert(static_cast<uint64_t>(std::distance(it, end)) <= max_size);
 
         for (size_t index = 0; it != end; ++it, ++index)
         {

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -417,6 +417,9 @@ class rank_support_int_v : public rank_support_int<alphabet_size>
     {
         assert(position <= text_size);
 
+        if (unlikely(text_size == 0)) // TODO: Maybe there could be some logic in the constructor for this case?
+            return 0;
+
         superblock_entry const & entry = superblocks[to_superblock_position(position)];
         return entry.template superblock_rank<compute_prefix_delta>(v) +
                entry.template block_rank<compute_prefix_delta>(position, v) +

--- a/include/sdsl/rank_support_int_v.hpp
+++ b/include/sdsl/rank_support_int_v.hpp
@@ -442,17 +442,19 @@ struct rank_support_int_v<alphabet_size, words_per_block, blocks_per_superblock>
     using size_type = typename base_t::size_type;
     //!\brief The offset used to jump to the correct block position.
     static constexpr size_t block_offset = effective_alphabet_size;
-    // static constexpr size_t bits_per_block_value = ceil_log2(values_per_superblock);
-    // static constexpr size_t block_values_per_word = 64 / bits_per_block_value;
-    // static constexpr size_t how many blocks do we need to store then?
-    // -> follows we can store 10 blocks in one word -> 5 blocks for one at the moment.
-    // How many do we need then? And we need to be able to access it later on.
-    // using bit_compressed_block = bit_compressed_word<uint32_t, bits_per_block_value>;
+    //!\brief How many bits needed to store the block ranks.
+    static constexpr size_t bits_per_block_value = ceil_log2(values_per_superblock);
+    //!\brief The smallest integer type needed to store the block ranks.
+    using block_value_type = std::conditional_t<bits_per_block_value <= 8,
+                                                uint8_t,
+                                                std::conditional_t<bits_per_block_value <= 16,
+                                                                   uint16_t,
+                                                                   uint32_t>>;
 
     //!\brief The array storing the super block values.
     std::array<uint64_t, (alphabet_size - 1)> superblocks;
     //!\brief The array storing the block values.
-    std::array<uint32_t, (blocks_per_superblock - 1) * (alphabet_size - 1)> blocks;
+    std::array<block_value_type, (blocks_per_superblock - 1) * (alphabet_size - 1)> blocks;
     //!\brief The array storing the bit compressed text.
     std::array<detail::bit_compressed_word<uint8_t, sigma_bits>, words_per_superblock> superblock_text;
 

--- a/include/sdsl/wavelet_trees.hpp
+++ b/include/sdsl/wavelet_trees.hpp
@@ -21,6 +21,7 @@
 #include <sdsl/wt_algorithm.hpp>
 #include <sdsl/wt_ap.hpp>
 #include <sdsl/wt_blcd.hpp>
+#include <sdsl/wt_epr.hpp>
 #include <sdsl/wt_gmr.hpp>
 #include <sdsl/wt_huff.hpp>
 #include <sdsl/wt_hutu.hpp>

--- a/include/sdsl/wt_epr.hpp
+++ b/include/sdsl/wt_epr.hpp
@@ -1,24 +1,26 @@
 // Copyright (c) 2016, the SDSL Project Authors.  All rights reserved.
 // Please see the AUTHORS file for details.  Use of this source code is governed
 // by a BSD license that can be found in the LICENSE file.
-/*! \file wt_epr.hpp
-    \brief wt_epr.hpp contains a class for the EPR dictionary of byte sequences.
-           The EPR-dictionary can be interpreted as a specialized wavelet tree of height 0.
-    \author Christopher Pockrandt
-*/
+/*!\file wt_epr.hpp
+ * \brief wt_epr.hpp contains a class for the EPR dictionary of byte sequences.
+ *        The EPR-dictionary can be interpreted as a specialized wavelet tree of height 0.
+ * \author Christopher Pockrandt
+ */
 #ifndef INCLUDED_SDSL_WT_EPR
 #define INCLUDED_SDSL_WT_EPR
 
-#include "int_vector.hpp"
-#include "rank_support_int.hpp"
-#include "wt_helper.hpp"
-#include <vector>
-#include <utility>
 #include <tuple>
 #include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <sdsl/int_vector.hpp>
+#include <sdsl/rank_support_int.hpp>
+#include <sdsl/wt_helper.hpp>
 
 //! Namespace for the succinct data structure library.
-namespace sdsl {
+namespace sdsl
+{
 
 //! An EPR-dictionary based wavelet.
 /*!
@@ -29,12 +31,10 @@ namespace sdsl {
  *
  *  @ingroup wt
  */
-template <uint8_t alphabet_size,
-          class rank_type    = rank_support_int_v<alphabet_size>,
-          class t_tree_strat = byte_tree<>
-          >
-class wt_epr {
-public:
+template <uint8_t alphabet_size, class rank_type = rank_support_int_v<alphabet_size>, class t_tree_strat = byte_tree<>>
+class wt_epr
+{
+  public:
     typedef typename t_tree_strat::template type<wt_epr> tree_strat_type;
     typedef int_vector<>::size_type size_type;
     typedef int_vector<>::value_type value_type;
@@ -42,33 +42,34 @@ public:
     // typedef const_iterator iterator;
     typedef wt_tag index_category;
     typedef byte_alphabet_tag /*typename tree_strat_type::alphabet_category*/ alphabet_category;
-    enum { lex_ordered = true };
+    enum
+    {
+        lex_ordered = true
+    };
 
-private:
+  private:
     //!\brief Check if underlying rank support structure stores the text implicitly.
     static constexpr bool has_inblock_text = std::is_same<rank_type, rank_support_int_v<alphabet_size>>::value;
 
-    size_type  m_size  = 0; // original text size
-    size_type  m_sigma = 0; // alphabet size
-    int_vector<>    m_bv; // bit vector to store the wavelet tree
-    rank_type  m_bv_rank; // rank support for the wavelet tree bit vector
+    size_type m_size = 0;  // original text size
+    size_type m_sigma = 0; // alphabet size
+    int_vector<> m_bv;     // bit vector to store the wavelet tree
+    rank_type m_bv_rank;   // rank support for the wavelet tree bit vector
 
     // Overload for the special epr rank structure.
     template <bool has_inblock_text_>
-    auto construct_init_rank_select(int_vector<> intermediate_bitvector)
-        -> std::enable_if_t<has_inblock_text_, void>
+    auto construct_init_rank_select(int_vector<> intermediate_bitvector) -> std::enable_if_t<has_inblock_text_, void>
     {
         // The text is stored inside of the rank structure so we do not store it here.
-        m_bv_rank = rank_type{&intermediate_bitvector}; // Create the rank support structure.
+        m_bv_rank = rank_type{ &intermediate_bitvector }; // Create the rank support structure.
     }
 
     // Overload for the other rank support structures.
     template <bool has_inblock_text_>
-    auto construct_init_rank_select(int_vector<> intermediate_bitvector)
-        -> std::enable_if_t<!has_inblock_text_, void>
+    auto construct_init_rank_select(int_vector<> intermediate_bitvector) -> std::enable_if_t<!has_inblock_text_, void>
     {
         m_bv = std::move(intermediate_bitvector);
-        m_bv_rank = rank_type{&m_bv}; // Create the rank support structure.
+        m_bv_rank = rank_type{ &m_bv }; // Create the rank support structure.
     }
 
     // Extract the text value from the given position.
@@ -88,9 +89,9 @@ private:
         return m_bv[position];
     }
 
-public:
-    const size_type& sigma = m_sigma;
-    const int_vector<>& bv = m_bv;
+  public:
+    const size_type & sigma = m_sigma;
+    const int_vector<> & bv = m_bv;
 
     // Default constructor
     wt_epr() = default;
@@ -103,7 +104,8 @@ public:
      *      \f$ \Order{n\log|\Sigma|}\f$, where \f$n=size\f$
      */
     template <typename t_it>
-    wt_epr(t_it begin, t_it end) : m_size(std::distance(begin, end))
+    wt_epr(t_it begin, t_it end)
+      : m_size(std::distance(begin, end))
     {
         if (0 == m_size) return;
         // O(n + |\Sigma|\log|\Sigma|) algorithm for calculating node sizes
@@ -118,8 +120,8 @@ public:
 
         // The text cannot have an alphabet larger than the required alphabet_size.
         if (m_sigma > alphabet_size)
-            throw std::domain_error{"The given text uses an alphabet that is larger than the explicitly given "
-                                    "alphabet size."};
+            throw std::domain_error{ "The given text uses an alphabet that is larger than the explicitly given "
+                                     "alphabet size." };
 
         // 4. Generate wavelet tree bit sequence m_bv
         int_vector<> intermediate_bitvector{};
@@ -133,44 +135,47 @@ public:
     }
 
     template <typename t_it>
-    wt_epr(t_it begin, t_it end, std::string) : wt_epr(begin, end)
+    wt_epr(t_it begin, t_it end, std::string)
+      : wt_epr(begin, end)
     {}
 
     //! Copy constructor
-    wt_epr(const wt_epr& wt)
-        : m_size(wt.m_size)
-        , m_sigma(wt.m_sigma)
-        , m_bv(wt.m_bv)
-        , m_bv_rank(wt.m_bv_rank)
+    wt_epr(const wt_epr & wt)
+      : m_size(wt.m_size)
+      , m_sigma(wt.m_sigma)
+      , m_bv(wt.m_bv)
+      , m_bv_rank(wt.m_bv_rank)
     {
         m_bv_rank.set_vector(&m_bv);
     }
 
-    wt_epr(wt_epr&& wt)
-        : m_size(wt.m_size)
-        , m_sigma(wt.m_sigma)
-        , m_bv(std::move(wt.m_bv))
-        , m_bv_rank(std::move(wt.m_bv_rank))
+    wt_epr(wt_epr && wt)
+      : m_size(wt.m_size)
+      , m_sigma(wt.m_sigma)
+      , m_bv(std::move(wt.m_bv))
+      , m_bv_rank(std::move(wt.m_bv_rank))
     {
         m_bv_rank.set_vector(&m_bv);
     }
 
     //! Assignment operator
-    wt_epr& operator=(const wt_epr& wt)
+    wt_epr & operator=(const wt_epr & wt)
     {
-        if (this != &wt) {
-            wt_epr tmp(wt); // re-use copy-constructor
+        if (this != &wt)
+        {
+            wt_epr tmp(wt);         // re-use copy-constructor
             *this = std::move(tmp); // re-use move-assignment
         }
         return *this;
     }
 
     //! Move assignment operator
-    wt_epr& operator=(wt_epr&& wt)
+    wt_epr & operator=(wt_epr && wt)
     {
-        if (this != &wt) {
+        if (this != &wt)
+        {
             m_size = wt.m_size;
-            m_sigma   = wt.m_sigma;
+            m_sigma = wt.m_sigma;
             m_bv = std::move(wt.m_bv);
             m_bv_rank = std::move(wt.m_bv_rank);
             m_bv_rank.set_vector(&m_bv);
@@ -293,12 +298,12 @@ public:
         size_type greater = j - i - m_bv_rank.prefix_rank(j, c) + prefix_i_c;
         if (c > 0)
         {
-            prefix_i_c_1 = m_bv_rank.prefix_rank(i, c-1);
-            smaller = m_bv_rank.prefix_rank(j, c-1) - prefix_i_c_1;
+            prefix_i_c_1 = m_bv_rank.prefix_rank(i, c - 1);
+            smaller = m_bv_rank.prefix_rank(j, c - 1) - prefix_i_c_1;
         }
         size_type rank = prefix_i_c - prefix_i_c_1;
 
-        return t_ret_type{rank, smaller, greater};
+        return t_ret_type{ rank, smaller, greater };
     }
 
     //! How many symbols are lexicographic smaller than c in [0..i-1].
@@ -319,9 +324,8 @@ public:
         assert(i <= size());
         // TODO: write a function returning a pair for (i, c) and (i, c-1) and benchmark!
         size_type prefix_count_smaller = 0;
-        if (c > 0)
-            prefix_count_smaller = m_bv_rank.prefix_rank(i, c - 1);
-        return t_ret_type{m_bv_rank.prefix_rank(i, c) - prefix_count_smaller, prefix_count_smaller};
+        if (c > 0) prefix_count_smaller = m_bv_rank.prefix_rank(i, c - 1);
+        return t_ret_type{ m_bv_rank.prefix_rank(i, c) - prefix_count_smaller, prefix_count_smaller };
     }
 
     //! Returns a const_iterator to the first element.
@@ -331,10 +335,9 @@ public:
     // const_iterator end() const { return const_iterator(this, size()); }
 
     //! Serializes the data structure into the given ostream
-    size_type
-    serialize(std::ostream& out, structure_tree_node* v = nullptr, std::string name = "") const
+    size_type serialize(std::ostream & out, structure_tree_node * v = nullptr, std::string name = "") const
     {
-        structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
+        structure_tree_node * child = structure_tree::add_child(v, name, util::class_name(*this));
         size_type written_bytes = 0;
         written_bytes += write_member(m_size, out, child, "size");
         written_bytes += write_member(m_sigma, out, child, "sigma");
@@ -345,7 +348,7 @@ public:
     }
 
     //! Loads the data structure from the given istream.
-    void load(std::istream& in)
+    void load(std::istream & in)
     {
         read_member(m_size, in);
         read_member(m_sigma, in);
@@ -371,8 +374,7 @@ public:
         ar(CEREAL_NVP(m_bv_rank));
         m_bv_rank.set_vector(&m_bv);
     }
-
 };
-}
+} // namespace sdsl
 
 #endif

--- a/include/sdsl/wt_epr.hpp
+++ b/include/sdsl/wt_epr.hpp
@@ -1,0 +1,347 @@
+// Copyright (c) 2016, the SDSL Project Authors.  All rights reserved.
+// Please see the AUTHORS file for details.  Use of this source code is governed
+// by a BSD license that can be found in the LICENSE file.
+/*! \file wt_epr.hpp
+    \brief wt_epr.hpp contains a class for the EPR dictionary of byte sequences.
+           The EPR-dictionary can be interpreted as a specialized wavelet tree of height 0.
+    \author Christopher Pockrandt
+*/
+#ifndef INCLUDED_SDSL_WT_EPR
+#define INCLUDED_SDSL_WT_EPR
+
+#include "int_vector.hpp"
+#include "rank_support_int.hpp"
+#include "wt_helper.hpp"
+#include <vector>
+#include <utility>
+#include <tuple>
+
+//! Namespace for the succinct data structure library.
+namespace sdsl {
+
+//! An EPR-dictionary based wavelet.
+/*!
+ * \tparam alphabet_size Size of the alphabet.
+ * \tparam t_rank        Rank support for pattern `1` on the bitvector.
+ * \tparam t_tree_strat  Tree strategy determines alphabet and the tree
+ *                       class used to navigate the WT.
+ *
+ *  @ingroup wt
+ */
+template <uint8_t alphabet_size,
+		  class rank_type    = rank_support_int_v<alphabet_size>,
+		  class t_tree_strat = byte_tree<>
+		  >
+class wt_epr {
+public:
+	typedef typename t_tree_strat::template type<wt_epr> tree_strat_type;
+	typedef int_vector<>::size_type						size_type;
+	typedef int_vector<>::value_type					value_type;
+	// typedef random_access_const_iterator<wt_pc>			const_iterator;
+	// typedef const_iterator								iterator;
+	typedef wt_tag										index_category;
+	typedef byte_alphabet_tag /*typename tree_strat_type::alphabet_category*/ alphabet_category;
+	enum { lex_ordered = true };
+
+private:
+
+	size_type		m_size  = 0;  // original text size
+	size_type		m_sigma = 0;  // alphabet size
+	int_vector<>    m_bv;		  // bit vector to store the wavelet tree
+	rank_type		m_bv_rank;	// rank support for the wavelet tree bit vector
+
+	void construct_init_rank_select()
+	{
+        rank_type temp(&m_bv);			 // generate a temporary support object
+        m_bv_rank = std::move(temp); // swap its content with the target object
+        m_bv_rank.set_vector(&m_bv);	 // set the support object's  pointer to x
+	}
+
+public:
+	const size_type&	   sigma = m_sigma;
+	const int_vector<>&    bv    = m_bv;
+
+	// Default constructor
+	wt_epr(){};
+
+	//! Construct the EPR-dictionary from a sequence defined by two interators
+	/*!
+         * \param begin Iterator to the start of the input.
+         * \param end   Iterator one past the end of the input.
+         * \par Time complexity
+         *      \f$ \Order{n\log|\Sigma|}\f$, where \f$n=size\f$
+         */
+	template <typename t_it>
+	wt_epr(t_it begin, t_it end) : m_size(std::distance(begin, end))
+	{
+		if (0 == m_size) return;
+		// O(n + |\Sigma|\log|\Sigma|) algorithm for calculating node sizes
+		// TODO: C should also depend on the tree_strategy. C is just a mapping
+		// from a symbol to its frequency. So a map<uint64_t,uint64_t> could be
+		// used for integer alphabets...
+		std::vector<size_type> C;
+		// 1. Count occurrences of characters
+		calculate_character_occurences(begin, end, C);
+		// 2. Calculate effective alphabet size
+		calculate_effective_alphabet_size(C, m_sigma);
+		// 4. Generate wavelet tree bit sequence m_bv
+
+		int_vector<> m_bv_tmp;
+		m_bv_tmp.width(std::ceil(std::log2(m_sigma)));
+		m_bv_tmp.resize(m_size);
+
+		size_type idx = 0;
+		for (t_it it = begin; it != end; ++it) {
+			m_bv_tmp[idx++] = *it;
+		}
+		int_vector<> m_bv2(m_bv_tmp);
+		m_bv = std::move(m_bv2); // swap its content with the target object
+		// 5. Initialize rank and select data structures for m_bv
+		construct_init_rank_select();
+	}
+
+	template <typename t_it>
+	wt_epr(t_it begin, t_it end, std::string) : wt_epr(begin, end)
+	{
+	}
+
+	//! Copy constructor
+	wt_epr(const wt_epr& wt)
+		: m_size(wt.m_size)
+		, m_sigma(wt.m_sigma)
+		, m_bv(wt.m_bv)
+		, m_bv_rank(wt.m_bv_rank)
+	{
+		m_bv_rank.set_vector(&m_bv);
+	}
+
+	wt_epr(wt_epr&& wt)
+		: m_size(wt.m_size)
+		, m_sigma(wt.m_sigma)
+		, m_bv(std::move(wt.m_bv))
+		, m_bv_rank(std::move(wt.m_bv_rank))
+	{
+		m_bv_rank.set_vector(&m_bv);
+	}
+
+	//! Assignment operator
+	wt_epr& operator=(const wt_epr& wt)
+	{
+		if (this != &wt) {
+			wt_epr tmp(wt);			// re-use copy-constructor
+			*this = std::move(tmp); // re-use move-assignment
+		}
+		return *this;
+	}
+
+	//! Move assignment operator
+	wt_epr& operator=(wt_epr&& wt)
+	{
+		if (this != &wt) {
+			m_size	= wt.m_size;
+			m_sigma   = wt.m_sigma;
+			m_bv	  = std::move(wt.m_bv);
+			m_bv_rank = std::move(wt.m_bv_rank);
+			m_bv_rank.set_vector(&m_bv);
+		}
+		return *this;
+	}
+
+	//! Returns the size of the original vector.
+	size_type size() const { return m_size; }
+
+	//! Returns whether the wavelet tree contains no data.
+	bool empty() const { return m_size == 0; }
+
+	//! Recovers the i-th symbol of the original vector.
+	/*!
+         * \param i Index in the original vector.
+         * \return The i-th symbol of the original vector.
+         * \par Time complexity
+         *      \f$ \Order{1} \f$
+         *
+         * \par Precondition
+         *      \f$ i < size() \f$
+         */
+	value_type operator[](size_type i) const
+	{
+		assert(i < size());
+		return m_bv[i];
+	};
+
+	//! Calculates how many symbols c are in the prefix [0..i-1].
+	/*!
+         * \param i Exclusive right bound of the range.
+         * \param c Symbol c.
+         * \return Number of occurrences of symbol c in the prefix [0..i-1].
+         * \par Time complexity
+         *      \f$ \Order{1} \f$
+         *
+         * \par Precondition
+         *      \f$ i \leq size() \f$
+         */
+
+	size_type rank(size_type i, value_type c) const
+	{
+		assert(i <= size());
+		return m_bv_rank.rank(i, c);
+	};
+
+	//! Calculates how many times symbol wt[i] occurs in the prefix [0..i-1].
+	/*!
+         * \param i The index of the symbol.
+         * \return  Pair (rank(wt[i],i),wt[i])
+         * \par Time complexity
+         *      \f$ \Order{1} \f$
+         *
+         * \par Precondition
+         *      \f$ i < size() \f$
+         */
+	std::pair<size_type, value_type> inverse_select(size_type i) const
+	{
+		assert(i < size());
+		return std::make_pair(m_bv_rank.rank(i, m_bv[i]), m_bv[i]);
+	}
+
+	// TODO: implement (if necessary?)
+	//! For each symbol c in wt[i..j-1] get rank(i,c) and rank(j,c).
+	/*!
+         * \param i        The start index (inclusive) of the interval.
+         * \param j        The end index (exclusive) of the interval.
+         * \param k        Reference for number of different symbols in [i..j-1].
+         * \param cs       Reference to a vector that will contain in
+         *                 cs[0..k-1] all symbols that occur in [i..j-1] in
+         *                 arbitrary order (if lex_ordered = false) and ascending
+         *                 order (if lex_ordered = true).
+         * \param rank_c_i Reference to a vector which equals
+         *                 rank_c_i[p] = rank(i,cs[p]), for \f$ 0 \leq p < k \f$.
+         * \param rank_c_j Reference to a vector which equals
+         *                 rank_c_j[p] = rank(j,cs[p]), for \f$ 0 \leq p < k \f$.
+         *
+         * \par Precondition
+         *      \f$ i \leq j \leq size() \f$
+         *      \f$ cs.size() \geq \sigma \f$
+         *      \f$ rank_{c_i}.size() \geq \sigma \f$
+         *      \f$ rank_{c_j}.size() \geq \sigma \f$
+         */
+	// void interval_symbols(size_type				   i,
+	// 					  size_type				   j,
+	// 					  size_type&			   k,
+	// 					  std::vector<value_type>& cs,
+	// 					  std::vector<size_type>&  rank_c_i,
+	// 					  std::vector<size_type>&  rank_c_j) const
+	// { }
+
+	//! How many symbols are lexicographic smaller/greater than c in [i..j-1].
+	/*!
+         * \param i       Start index (inclusive) of the interval.
+         * \param j       End index (exclusive) of the interval.
+         * \param c       Symbol c.
+         * \return A triple containing:
+         *         * rank(i,c)
+         *         * #symbols smaller than c in [i..j-1]
+         *         * #symbols greater than c in [i..j-1]
+         *
+         * \par Precondition
+         *       \f$ i \leq j \leq size() \f$
+         */
+	template <class t_ret_type = std::tuple<size_type, size_type, size_type>>
+	t_ret_type lex_count(size_type i, size_type j, value_type c) const
+	{
+		assert(i <= j and j <= size());
+		// size_type smaller = 0;
+		// size_type greater = (j - i) - (m_bv_rank.prefix_rank(j, c) - m_bv_rank.prefix_rank(i, c));
+		// if (c > 0)
+		// 	smaller = m_bv_rank.prefix_rank(j, c-1) - m_bv_rank.prefix_rank(i, c-1);
+		// size_type rank = m_bv_rank.rank(i, c);
+
+		// TODO: write a function returning a pair for (i, c) and (i, c-1) and benchmark!
+		size_type smaller = 0;
+		size_type prefix_i_c = m_bv_rank.prefix_rank(i, c);
+		size_type prefix_i_c_1 = 0;
+		size_type greater = j - i - m_bv_rank.prefix_rank(j, c) + prefix_i_c;
+		if (c > 0)
+		{
+			prefix_i_c_1 = m_bv_rank.prefix_rank(i, c-1);
+			smaller = m_bv_rank.prefix_rank(j, c-1) - prefix_i_c_1;
+		}
+		size_type rank = prefix_i_c - prefix_i_c_1;
+
+		return t_ret_type{rank, smaller, greater};
+	}
+
+	//! How many symbols are lexicographic smaller than c in [0..i-1].
+	/*!
+         * \param i Exclusive right bound of the range.
+         * \param c Symbol c.
+         * \return A tuple containing:
+         *         * rank(i,c)
+         *         * #symbols smaller than c in [0..i-1]
+         * \par Precondition
+         *       \f$ i \leq size() \f$
+         * \note
+         * This method is only available if lex_ordered = true
+         */
+	template <class t_ret_type = std::tuple<size_type, size_type>>
+	t_ret_type lex_smaller_count(size_type i, value_type c) const
+	{
+		assert(i <= size());
+		// TODO: write a function returning a pair for (i, c) and (i, c-1) and benchmark!
+		size_type prefix_count_smaller = 0;
+		if (c > 0)
+			prefix_count_smaller = m_bv_rank.prefix_rank(i, c - 1);
+		return t_ret_type{m_bv_rank.prefix_rank(i, c) - prefix_count_smaller, prefix_count_smaller};
+	}
+
+	//! Returns a const_iterator to the first element.
+	// const_iterator begin() const { return const_iterator(this, 0); }
+	//
+	// //! Returns a const_iterator to the element after the last element.
+	// const_iterator end() const { return const_iterator(this, size()); }
+
+	//! Serializes the data structure into the given ostream
+	size_type
+	serialize(std::ostream& out, structure_tree_node* v = nullptr, std::string name = "") const
+	{
+		structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
+		size_type written_bytes = 0;
+		written_bytes += write_member(m_size, out, child, "size");
+		written_bytes += write_member(m_sigma, out, child, "sigma");
+		written_bytes += m_bv.serialize(out, child, "bv");
+		written_bytes += m_bv_rank.serialize(out, child, "bv_rank");
+		structure_tree::add_size(child, written_bytes);
+		return written_bytes;
+	}
+
+	//! Loads the data structure from the given istream.
+	void load(std::istream& in)
+	{
+		read_member(m_size, in);
+		read_member(m_sigma, in);
+		m_bv.load(in);
+		m_bv_rank.load(in, &m_bv);
+	}
+
+	template <typename archive_t>
+	void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
+	{
+		ar(CEREAL_NVP(m_size));
+		ar(CEREAL_NVP(m_sigma));
+		ar(CEREAL_NVP(m_bv));
+		ar(CEREAL_NVP(m_bv_rank));
+	}
+
+	template <typename archive_t>
+	void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
+	{
+		ar(CEREAL_NVP(m_size));
+		ar(CEREAL_NVP(m_sigma));
+		ar(CEREAL_NVP(m_bv));
+		ar(CEREAL_NVP(m_bv_rank));
+		m_bv_rank.set_vector(&m_bv);
+	}
+
+};
+}
+
+#endif

--- a/include/sdsl/wt_epr.hpp
+++ b/include/sdsl/wt_epr.hpp
@@ -356,6 +356,16 @@ class wt_epr
         m_bv_rank.load(in, &m_bv);
     }
 
+    //! Equality operator.
+    friend bool operator==(wt_epr const & lhs, wt_epr const & rhs) noexcept
+    {
+        return (lhs.m_size == rhs.m_size) && (lhs.m_sigma == rhs.m_sigma) && (lhs.m_bv == rhs.m_bv) &&
+               (lhs.m_bv_rank == rhs.m_bv_rank);
+    }
+
+    //! Inequality operator.
+    friend bool operator!=(wt_epr const & lhs, wt_epr const & rhs) noexcept { return !(lhs == rhs); }
+
     template <typename archive_t>
     void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
     {

--- a/include/sdsl/wt_epr.hpp
+++ b/include/sdsl/wt_epr.hpp
@@ -29,317 +29,316 @@ namespace sdsl {
  *  @ingroup wt
  */
 template <uint8_t alphabet_size,
-		  class rank_type    = rank_support_int_v<alphabet_size>,
-		  class t_tree_strat = byte_tree<>
-		  >
+          class rank_type    = rank_support_int_v<alphabet_size>,
+          class t_tree_strat = byte_tree<>
+          >
 class wt_epr {
 public:
-	typedef typename t_tree_strat::template type<wt_epr> tree_strat_type;
-	typedef int_vector<>::size_type						size_type;
-	typedef int_vector<>::value_type					value_type;
-	// typedef random_access_const_iterator<wt_pc>			const_iterator;
-	// typedef const_iterator								iterator;
-	typedef wt_tag										index_category;
-	typedef byte_alphabet_tag /*typename tree_strat_type::alphabet_category*/ alphabet_category;
-	enum { lex_ordered = true };
+    typedef typename t_tree_strat::template type<wt_epr> tree_strat_type;
+    typedef int_vector<>::size_type size_type;
+    typedef int_vector<>::value_type value_type;
+    // typedef random_access_const_iterator<wt_pc> const_iterator;
+    // typedef const_iterator iterator;
+    typedef wt_tag index_category;
+    typedef byte_alphabet_tag /*typename tree_strat_type::alphabet_category*/ alphabet_category;
+    enum { lex_ordered = true };
 
 private:
 
-	size_type		m_size  = 0;  // original text size
-	size_type		m_sigma = 0;  // alphabet size
-	int_vector<>    m_bv;		  // bit vector to store the wavelet tree
-	rank_type		m_bv_rank;	// rank support for the wavelet tree bit vector
+    size_type  m_size  = 0; // original text size
+    size_type  m_sigma = 0; // alphabet size
+    int_vector<>    m_bv; // bit vector to store the wavelet tree
+    rank_type  m_bv_rank; // rank support for the wavelet tree bit vector
 
-	void construct_init_rank_select()
-	{
-        rank_type temp(&m_bv);			 // generate a temporary support object
+    void construct_init_rank_select()
+    {
+        rank_type temp(&m_bv); // generate a temporary support object
         m_bv_rank = std::move(temp); // swap its content with the target object
-        m_bv_rank.set_vector(&m_bv);	 // set the support object's  pointer to x
-	}
+        m_bv_rank.set_vector(&m_bv); // set the support object's  pointer to x
+    }
 
 public:
-	const size_type&	   sigma = m_sigma;
-	const int_vector<>&    bv    = m_bv;
+    const size_type& sigma = m_sigma;
+    const int_vector<>& bv = m_bv;
 
-	// Default constructor
-	wt_epr(){};
+    // Default constructor
+    wt_epr(){};
 
-	//! Construct the EPR-dictionary from a sequence defined by two interators
-	/*!
+    //! Construct the EPR-dictionary from a sequence defined by two interators
+    /*!
          * \param begin Iterator to the start of the input.
          * \param end   Iterator one past the end of the input.
          * \par Time complexity
          *      \f$ \Order{n\log|\Sigma|}\f$, where \f$n=size\f$
          */
-	template <typename t_it>
-	wt_epr(t_it begin, t_it end) : m_size(std::distance(begin, end))
-	{
-		if (0 == m_size) return;
-		// O(n + |\Sigma|\log|\Sigma|) algorithm for calculating node sizes
-		// TODO: C should also depend on the tree_strategy. C is just a mapping
-		// from a symbol to its frequency. So a map<uint64_t,uint64_t> could be
-		// used for integer alphabets...
-		std::vector<size_type> C;
-		// 1. Count occurrences of characters
-		calculate_character_occurences(begin, end, C);
-		// 2. Calculate effective alphabet size
-		calculate_effective_alphabet_size(C, m_sigma);
-		// 4. Generate wavelet tree bit sequence m_bv
+    template <typename t_it>
+    wt_epr(t_it begin, t_it end) : m_size(std::distance(begin, end))
+    {
+        if (0 == m_size) return;
+        // O(n + |\Sigma|\log|\Sigma|) algorithm for calculating node sizes
+        // TODO: C should also depend on the tree_strategy. C is just a mapping
+        // from a symbol to its frequency. So a map<uint64_t,uint64_t> could be
+        // used for integer alphabets...
+        std::vector<size_type> C;
+        // 1. Count occurrences of characters
+        calculate_character_occurences(begin, end, C);
+        // 2. Calculate effective alphabet size
+        calculate_effective_alphabet_size(C, m_sigma);
+        // 4. Generate wavelet tree bit sequence m_bv
 
-		int_vector<> m_bv_tmp;
-		m_bv_tmp.width(std::ceil(std::log2(m_sigma)));
-		m_bv_tmp.resize(m_size);
+        int_vector<> m_bv_tmp;
+        m_bv_tmp.width(std::ceil(std::log2(m_sigma)));
+        m_bv_tmp.resize(m_size);
 
-		size_type idx = 0;
-		for (t_it it = begin; it != end; ++it) {
-			m_bv_tmp[idx++] = *it;
-		}
-		int_vector<> m_bv2(m_bv_tmp);
-		m_bv = std::move(m_bv2); // swap its content with the target object
-		// 5. Initialize rank and select data structures for m_bv
-		construct_init_rank_select();
-	}
+        size_type idx = 0;
+        for (t_it it = begin; it != end; ++it) {
+            m_bv_tmp[idx++] = *it;
+        }
+        int_vector<> m_bv2(m_bv_tmp);
+        m_bv = std::move(m_bv2); // swap its content with the target object
+        // 5. Initialize rank and select data structures for m_bv
+        construct_init_rank_select();
+    }
 
-	template <typename t_it>
-	wt_epr(t_it begin, t_it end, std::string) : wt_epr(begin, end)
-	{
-	}
+    template <typename t_it>
+    wt_epr(t_it begin, t_it end, std::string) : wt_epr(begin, end)
+    {
+    }
 
-	//! Copy constructor
-	wt_epr(const wt_epr& wt)
-		: m_size(wt.m_size)
-		, m_sigma(wt.m_sigma)
-		, m_bv(wt.m_bv)
-		, m_bv_rank(wt.m_bv_rank)
-	{
-		m_bv_rank.set_vector(&m_bv);
-	}
+    //! Copy constructor
+    wt_epr(const wt_epr& wt)
+        : m_size(wt.m_size)
+        , m_sigma(wt.m_sigma)
+        , m_bv(wt.m_bv)
+        , m_bv_rank(wt.m_bv_rank)
+    {
+        m_bv_rank.set_vector(&m_bv);
+    }
 
-	wt_epr(wt_epr&& wt)
-		: m_size(wt.m_size)
-		, m_sigma(wt.m_sigma)
-		, m_bv(std::move(wt.m_bv))
-		, m_bv_rank(std::move(wt.m_bv_rank))
-	{
-		m_bv_rank.set_vector(&m_bv);
-	}
+    wt_epr(wt_epr&& wt)
+        : m_size(wt.m_size)
+        , m_sigma(wt.m_sigma)
+        , m_bv(std::move(wt.m_bv))
+        , m_bv_rank(std::move(wt.m_bv_rank))
+    {
+        m_bv_rank.set_vector(&m_bv);
+    }
 
-	//! Assignment operator
-	wt_epr& operator=(const wt_epr& wt)
-	{
-		if (this != &wt) {
-			wt_epr tmp(wt);			// re-use copy-constructor
-			*this = std::move(tmp); // re-use move-assignment
-		}
-		return *this;
-	}
+    //! Assignment operator
+    wt_epr& operator=(const wt_epr& wt)
+    {
+        if (this != &wt) {
+            wt_epr tmp(wt); // re-use copy-constructor
+            *this = std::move(tmp); // re-use move-assignment
+        }
+        return *this;
+    }
 
-	//! Move assignment operator
-	wt_epr& operator=(wt_epr&& wt)
-	{
-		if (this != &wt) {
-			m_size	= wt.m_size;
-			m_sigma   = wt.m_sigma;
-			m_bv	  = std::move(wt.m_bv);
-			m_bv_rank = std::move(wt.m_bv_rank);
-			m_bv_rank.set_vector(&m_bv);
-		}
-		return *this;
-	}
+    //! Move assignment operator
+    wt_epr& operator=(wt_epr&& wt)
+    {
+        if (this != &wt) {
+            m_size = wt.m_size;
+            m_sigma   = wt.m_sigma;
+            m_bv = std::move(wt.m_bv);
+            m_bv_rank = std::move(wt.m_bv_rank);
+            m_bv_rank.set_vector(&m_bv);
+        }
+        return *this;
+    }
 
-	//! Returns the size of the original vector.
-	size_type size() const { return m_size; }
+    //! Returns the size of the original vector.
+    size_type size() const { return m_size; }
 
-	//! Returns whether the wavelet tree contains no data.
-	bool empty() const { return m_size == 0; }
+    //! Returns whether the wavelet tree contains no data.
+    bool empty() const { return m_size == 0; }
 
-	//! Recovers the i-th symbol of the original vector.
-	/*!
-         * \param i Index in the original vector.
-         * \return The i-th symbol of the original vector.
-         * \par Time complexity
-         *      \f$ \Order{1} \f$
-         *
-         * \par Precondition
-         *      \f$ i < size() \f$
-         */
-	value_type operator[](size_type i) const
-	{
-		assert(i < size());
-		return m_bv[i];
-	};
+    //! Recovers the i-th symbol of the original vector.
+    /*!
+     * \param i Index in the original vector.
+     * \return The i-th symbol of the original vector.
+     * \par Time complexity
+     *      \f$ \Order{1} \f$
+     *
+     * \par Precondition
+     *      \f$ i < size() \f$
+     */
+    value_type operator[](size_type i) const
+    {
+        assert(i < size());
+        return m_bv[i];
+    };
 
-	//! Calculates how many symbols c are in the prefix [0..i-1].
-	/*!
-         * \param i Exclusive right bound of the range.
-         * \param c Symbol c.
-         * \return Number of occurrences of symbol c in the prefix [0..i-1].
-         * \par Time complexity
-         *      \f$ \Order{1} \f$
-         *
-         * \par Precondition
-         *      \f$ i \leq size() \f$
-         */
+    //! Calculates how many symbols c are in the prefix [0..i-1].
+    /*!
+     * \param i Exclusive right bound of the range.
+     * \param c Symbol c.
+     * \return Number of occurrences of symbol c in the prefix [0..i-1].
+     * \par Time complexity
+     *      \f$ \Order{1} \f$
+     *
+     * \par Precondition
+     *      \f$ i \leq size() \f$
+     */
+    size_type rank(size_type i, value_type c) const
+    {
+        assert(i <= size());
+        return m_bv_rank.rank(i, c);
+    };
 
-	size_type rank(size_type i, value_type c) const
-	{
-		assert(i <= size());
-		return m_bv_rank.rank(i, c);
-	};
+    //! Calculates how many times symbol wt[i] occurs in the prefix [0..i-1].
+    /*!
+     * \param i The index of the symbol.
+     * \return  Pair (rank(wt[i],i),wt[i])
+     * \par Time complexity
+     *      \f$ \Order{1} \f$
+     *
+     * \par Precondition
+     *      \f$ i < size() \f$
+     */
+    std::pair<size_type, value_type> inverse_select(size_type i) const
+    {
+        assert(i < size());
+        return std::make_pair(m_bv_rank.rank(i, m_bv[i]), m_bv[i]);
+    }
 
-	//! Calculates how many times symbol wt[i] occurs in the prefix [0..i-1].
-	/*!
-         * \param i The index of the symbol.
-         * \return  Pair (rank(wt[i],i),wt[i])
-         * \par Time complexity
-         *      \f$ \Order{1} \f$
-         *
-         * \par Precondition
-         *      \f$ i < size() \f$
-         */
-	std::pair<size_type, value_type> inverse_select(size_type i) const
-	{
-		assert(i < size());
-		return std::make_pair(m_bv_rank.rank(i, m_bv[i]), m_bv[i]);
-	}
+    // TODO: implement (if necessary?)
+    //! For each symbol c in wt[i..j-1] get rank(i,c) and rank(j,c).
+    /*!
+     * \param i        The start index (inclusive) of the interval.
+     * \param j        The end index (exclusive) of the interval.
+     * \param k        Reference for number of different symbols in [i..j-1].
+     * \param cs       Reference to a vector that will contain in
+     *                 cs[0..k-1] all symbols that occur in [i..j-1] in
+     *                 arbitrary order (if lex_ordered = false) and ascending
+     *                 order (if lex_ordered = true).
+     * \param rank_c_i Reference to a vector which equals
+     *                 rank_c_i[p] = rank(i,cs[p]), for \f$ 0 \leq p < k \f$.
+     * \param rank_c_j Reference to a vector which equals
+     *                 rank_c_j[p] = rank(j,cs[p]), for \f$ 0 \leq p < k \f$.
+     *
+     * \par Precondition
+     *      \f$ i \leq j \leq size() \f$
+     *      \f$ cs.size() \geq \sigma \f$
+     *      \f$ rank_{c_i}.size() \geq \sigma \f$
+     *      \f$ rank_{c_j}.size() \geq \sigma \f$
+     */
+    // void interval_symbols(size_type       i,
+    //        size_type       j,
+    //        size_type&      k,
+    //        std::vector<value_type>& cs,
+    //        std::vector<size_type>&  rank_c_i,
+    //        std::vector<size_type>&  rank_c_j) const
+    // { }
 
-	// TODO: implement (if necessary?)
-	//! For each symbol c in wt[i..j-1] get rank(i,c) and rank(j,c).
-	/*!
-         * \param i        The start index (inclusive) of the interval.
-         * \param j        The end index (exclusive) of the interval.
-         * \param k        Reference for number of different symbols in [i..j-1].
-         * \param cs       Reference to a vector that will contain in
-         *                 cs[0..k-1] all symbols that occur in [i..j-1] in
-         *                 arbitrary order (if lex_ordered = false) and ascending
-         *                 order (if lex_ordered = true).
-         * \param rank_c_i Reference to a vector which equals
-         *                 rank_c_i[p] = rank(i,cs[p]), for \f$ 0 \leq p < k \f$.
-         * \param rank_c_j Reference to a vector which equals
-         *                 rank_c_j[p] = rank(j,cs[p]), for \f$ 0 \leq p < k \f$.
-         *
-         * \par Precondition
-         *      \f$ i \leq j \leq size() \f$
-         *      \f$ cs.size() \geq \sigma \f$
-         *      \f$ rank_{c_i}.size() \geq \sigma \f$
-         *      \f$ rank_{c_j}.size() \geq \sigma \f$
-         */
-	// void interval_symbols(size_type				   i,
-	// 					  size_type				   j,
-	// 					  size_type&			   k,
-	// 					  std::vector<value_type>& cs,
-	// 					  std::vector<size_type>&  rank_c_i,
-	// 					  std::vector<size_type>&  rank_c_j) const
-	// { }
+    //! How many symbols are lexicographic smaller/greater than c in [i..j-1].
+    /*!
+     * \param i       Start index (inclusive) of the interval.
+     * \param j       End index (exclusive) of the interval.
+     * \param c       Symbol c.
+     * \return A triple containing:
+     *         * rank(i,c)
+     *         * #symbols smaller than c in [i..j-1]
+     *         * #symbols greater than c in [i..j-1]
+     *
+     * \par Precondition
+     *       \f$ i \leq j \leq size() \f$
+     */
+    template <class t_ret_type = std::tuple<size_type, size_type, size_type>>
+    t_ret_type lex_count(size_type i, size_type j, value_type c) const
+    {
+        assert(i <= j and j <= size());
+        // size_type smaller = 0;
+        // size_type greater = (j - i) - (m_bv_rank.prefix_rank(j, c) - m_bv_rank.prefix_rank(i, c));
+        // if (c > 0)
+        //     smaller = m_bv_rank.prefix_rank(j, c-1) - m_bv_rank.prefix_rank(i, c-1);
+        // size_type rank = m_bv_rank.rank(i, c);
 
-	//! How many symbols are lexicographic smaller/greater than c in [i..j-1].
-	/*!
-         * \param i       Start index (inclusive) of the interval.
-         * \param j       End index (exclusive) of the interval.
-         * \param c       Symbol c.
-         * \return A triple containing:
-         *         * rank(i,c)
-         *         * #symbols smaller than c in [i..j-1]
-         *         * #symbols greater than c in [i..j-1]
-         *
-         * \par Precondition
-         *       \f$ i \leq j \leq size() \f$
-         */
-	template <class t_ret_type = std::tuple<size_type, size_type, size_type>>
-	t_ret_type lex_count(size_type i, size_type j, value_type c) const
-	{
-		assert(i <= j and j <= size());
-		// size_type smaller = 0;
-		// size_type greater = (j - i) - (m_bv_rank.prefix_rank(j, c) - m_bv_rank.prefix_rank(i, c));
-		// if (c > 0)
-		// 	smaller = m_bv_rank.prefix_rank(j, c-1) - m_bv_rank.prefix_rank(i, c-1);
-		// size_type rank = m_bv_rank.rank(i, c);
+        // TODO: write a function returning a pair for (i, c) and (i, c-1) and benchmark!
+        size_type smaller = 0;
+        size_type prefix_i_c = m_bv_rank.prefix_rank(i, c);
+        size_type prefix_i_c_1 = 0;
+        size_type greater = j - i - m_bv_rank.prefix_rank(j, c) + prefix_i_c;
+        if (c > 0)
+        {
+            prefix_i_c_1 = m_bv_rank.prefix_rank(i, c-1);
+            smaller = m_bv_rank.prefix_rank(j, c-1) - prefix_i_c_1;
+        }
+        size_type rank = prefix_i_c - prefix_i_c_1;
 
-		// TODO: write a function returning a pair for (i, c) and (i, c-1) and benchmark!
-		size_type smaller = 0;
-		size_type prefix_i_c = m_bv_rank.prefix_rank(i, c);
-		size_type prefix_i_c_1 = 0;
-		size_type greater = j - i - m_bv_rank.prefix_rank(j, c) + prefix_i_c;
-		if (c > 0)
-		{
-			prefix_i_c_1 = m_bv_rank.prefix_rank(i, c-1);
-			smaller = m_bv_rank.prefix_rank(j, c-1) - prefix_i_c_1;
-		}
-		size_type rank = prefix_i_c - prefix_i_c_1;
+        return t_ret_type{rank, smaller, greater};
+    }
 
-		return t_ret_type{rank, smaller, greater};
-	}
+    //! How many symbols are lexicographic smaller than c in [0..i-1].
+    /*!
+     * \param i Exclusive right bound of the range.
+     * \param c Symbol c.
+     * \return A tuple containing:
+     *         * rank(i,c)
+     *         * #symbols smaller than c in [0..i-1]
+     * \par Precondition
+     *       \f$ i \leq size() \f$
+     * \note
+     * This method is only available if lex_ordered = true
+     */
+    template <class t_ret_type = std::tuple<size_type, size_type>>
+    t_ret_type lex_smaller_count(size_type i, value_type c) const
+    {
+        assert(i <= size());
+        // TODO: write a function returning a pair for (i, c) and (i, c-1) and benchmark!
+        size_type prefix_count_smaller = 0;
+        if (c > 0)
+            prefix_count_smaller = m_bv_rank.prefix_rank(i, c - 1);
+        return t_ret_type{m_bv_rank.prefix_rank(i, c) - prefix_count_smaller, prefix_count_smaller};
+    }
 
-	//! How many symbols are lexicographic smaller than c in [0..i-1].
-	/*!
-         * \param i Exclusive right bound of the range.
-         * \param c Symbol c.
-         * \return A tuple containing:
-         *         * rank(i,c)
-         *         * #symbols smaller than c in [0..i-1]
-         * \par Precondition
-         *       \f$ i \leq size() \f$
-         * \note
-         * This method is only available if lex_ordered = true
-         */
-	template <class t_ret_type = std::tuple<size_type, size_type>>
-	t_ret_type lex_smaller_count(size_type i, value_type c) const
-	{
-		assert(i <= size());
-		// TODO: write a function returning a pair for (i, c) and (i, c-1) and benchmark!
-		size_type prefix_count_smaller = 0;
-		if (c > 0)
-			prefix_count_smaller = m_bv_rank.prefix_rank(i, c - 1);
-		return t_ret_type{m_bv_rank.prefix_rank(i, c) - prefix_count_smaller, prefix_count_smaller};
-	}
+    //! Returns a const_iterator to the first element.
+    // const_iterator begin() const { return const_iterator(this, 0); }
+    //
+    // //! Returns a const_iterator to the element after the last element.
+    // const_iterator end() const { return const_iterator(this, size()); }
 
-	//! Returns a const_iterator to the first element.
-	// const_iterator begin() const { return const_iterator(this, 0); }
-	//
-	// //! Returns a const_iterator to the element after the last element.
-	// const_iterator end() const { return const_iterator(this, size()); }
+    //! Serializes the data structure into the given ostream
+    size_type
+    serialize(std::ostream& out, structure_tree_node* v = nullptr, std::string name = "") const
+    {
+        structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
+        size_type written_bytes = 0;
+        written_bytes += write_member(m_size, out, child, "size");
+        written_bytes += write_member(m_sigma, out, child, "sigma");
+        written_bytes += m_bv.serialize(out, child, "bv");
+        written_bytes += m_bv_rank.serialize(out, child, "bv_rank");
+        structure_tree::add_size(child, written_bytes);
+        return written_bytes;
+    }
 
-	//! Serializes the data structure into the given ostream
-	size_type
-	serialize(std::ostream& out, structure_tree_node* v = nullptr, std::string name = "") const
-	{
-		structure_tree_node* child = structure_tree::add_child(v, name, util::class_name(*this));
-		size_type written_bytes = 0;
-		written_bytes += write_member(m_size, out, child, "size");
-		written_bytes += write_member(m_sigma, out, child, "sigma");
-		written_bytes += m_bv.serialize(out, child, "bv");
-		written_bytes += m_bv_rank.serialize(out, child, "bv_rank");
-		structure_tree::add_size(child, written_bytes);
-		return written_bytes;
-	}
+    //! Loads the data structure from the given istream.
+    void load(std::istream& in)
+    {
+        read_member(m_size, in);
+        read_member(m_sigma, in);
+        m_bv.load(in);
+        m_bv_rank.load(in, &m_bv);
+    }
 
-	//! Loads the data structure from the given istream.
-	void load(std::istream& in)
-	{
-		read_member(m_size, in);
-		read_member(m_sigma, in);
-		m_bv.load(in);
-		m_bv_rank.load(in, &m_bv);
-	}
+    template <typename archive_t>
+    void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
+    {
+        ar(CEREAL_NVP(m_size));
+        ar(CEREAL_NVP(m_sigma));
+        ar(CEREAL_NVP(m_bv));
+        ar(CEREAL_NVP(m_bv_rank));
+    }
 
-	template <typename archive_t>
-	void CEREAL_SAVE_FUNCTION_NAME(archive_t & ar) const
-	{
-		ar(CEREAL_NVP(m_size));
-		ar(CEREAL_NVP(m_sigma));
-		ar(CEREAL_NVP(m_bv));
-		ar(CEREAL_NVP(m_bv_rank));
-	}
-
-	template <typename archive_t>
-	void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
-	{
-		ar(CEREAL_NVP(m_size));
-		ar(CEREAL_NVP(m_sigma));
-		ar(CEREAL_NVP(m_bv));
-		ar(CEREAL_NVP(m_bv_rank));
-		m_bv_rank.set_vector(&m_bv);
-	}
+    template <typename archive_t>
+    void CEREAL_LOAD_FUNCTION_NAME(archive_t & ar)
+    {
+        ar(CEREAL_NVP(m_size));
+        ar(CEREAL_NVP(m_sigma));
+        ar(CEREAL_NVP(m_bv));
+        ar(CEREAL_NVP(m_bv_rank));
+        m_bv_rank.set_vector(&m_bv);
+    }
 
 };
 }

--- a/include/sdsl/wt_epr.hpp
+++ b/include/sdsl/wt_epr.hpp
@@ -38,8 +38,9 @@ class wt_epr
     typedef typename t_tree_strat::template type<wt_epr> tree_strat_type;
     typedef int_vector<>::size_type size_type;
     typedef int_vector<>::value_type value_type;
-    // typedef random_access_const_iterator<wt_pc> const_iterator;
-    // typedef const_iterator iterator;
+    typedef random_access_const_iterator<wt_epr> const_iterator;
+    typedef const_iterator iterator;
+    typedef typename int_vector<>::difference_type difference_type;
     typedef wt_tag index_category;
     typedef byte_alphabet_tag /*typename tree_strat_type::alphabet_category*/ alphabet_category;
     enum
@@ -329,10 +330,10 @@ class wt_epr
     }
 
     //! Returns a const_iterator to the first element.
-    // const_iterator begin() const { return const_iterator(this, 0); }
-    //
-    // //! Returns a const_iterator to the element after the last element.
-    // const_iterator end() const { return const_iterator(this, size()); }
+    const_iterator begin() const { return const_iterator(this, 0); }
+
+    //! Returns a const_iterator to the element after the last element.
+    const_iterator end() const { return const_iterator(this, size()); }
 
     //! Serializes the data structure into the given ostream
     size_type serialize(std::ostream & out, structure_tree_node * v = nullptr, std::string name = "") const

--- a/test/wt_byte_epr_test.cpp
+++ b/test/wt_byte_epr_test.cpp
@@ -29,7 +29,7 @@ using testing::Types;
 
 typedef Types<wt_epr<4>> Implementations;
 
-TYPED_TEST_CASE(wt_byte_epr_test, Implementations);
+TYPED_TEST_SUITE(wt_byte_epr_test, Implementations, );
 
 TYPED_TEST(wt_byte_epr_test, create_and_store)
 {

--- a/test/wt_byte_epr_test.cpp
+++ b/test/wt_byte_epr_test.cpp
@@ -1,0 +1,189 @@
+#include "sdsl/wavelet_trees.hpp"
+#include "common.hpp"
+#include "gtest/gtest.h"
+#include <vector>
+#include <string>
+#include <algorithm> // for std::min
+#include <random>
+
+namespace
+{
+
+using namespace sdsl;
+using namespace std;
+
+typedef int_vector<>::size_type size_type;
+
+string temp_file;
+string temp_dir;
+int_vector<8> text;
+
+template<class T>
+class wt_byte_epr_test : public ::testing::Test { };
+
+using testing::Types;
+
+typedef Types<
+    wt_epr<4>
+> Implementations;
+
+TYPED_TEST_CASE(wt_byte_epr_test, Implementations);
+
+TYPED_TEST(wt_byte_epr_test, create_and_store)
+{
+    static_assert(sdsl::util::is_regular<TypeParam>::value, "Type is not regular");
+
+    text.resize(std::rand() % 10000);
+
+    for (uint32_t i = 0; i < text.size(); ++i)
+    {
+        text[i] = (std::rand() % 3) + 1; // no 0s allowed. produces 1, 2 or 3.
+    }
+
+    TypeParam wt(text.begin(), text.end());
+
+    ASSERT_TRUE(store_to_file(wt, temp_file));
+}
+
+//! Test sigma
+TYPED_TEST(wt_byte_epr_test, sigma)
+{
+    TypeParam wt;
+    ASSERT_TRUE(load_from_file(wt, temp_file));
+    ASSERT_EQ(text.size(), wt.size());
+    bit_vector occur(256, 0);
+    uint16_t sigma = 0;
+    for (size_type j=0; j<text.size(); ++j) {
+        if (!occur[(unsigned char)text[j]]) {
+            occur[(unsigned char)text[j]] = 1;
+            ++sigma;
+        }
+    }
+    ASSERT_EQ(sigma, wt.sigma);
+}
+
+template<class t_wt>
+void compare_wt(const int_vector<8>& text, const t_wt& wt)
+{
+    ASSERT_EQ(text.size(), wt.size());
+    for (size_type j=0; j<text.size(); ++j) {
+        ASSERT_EQ((typename t_wt::value_type)text[j], wt[j])<<" j="<<j;
+    }
+}
+
+//! Test Access method, Copy-construtor, Move-constructor, Copy-assign and Move-assign
+TYPED_TEST(wt_byte_epr_test, access_copy_move_and_swap)
+{
+    TypeParam wt;
+    ASSERT_TRUE(load_from_file(wt, temp_file));
+    compare_wt(text, wt);
+
+    // Copy-constructor
+    TypeParam wt2(wt);
+    compare_wt(text, wt2);
+
+    // Move-constructor
+    TypeParam wt3(std::move(wt2));
+    compare_wt(text, wt3);
+
+    // Copy-Assign
+    TypeParam wt4;
+    wt4 = wt3;
+    compare_wt(text, wt4);
+
+    // Move-Assign
+    TypeParam wt5;
+    wt5 = std::move(wt4);
+    compare_wt(text, wt5);
+}
+
+//! Test rank methods
+TYPED_TEST(wt_byte_epr_test, rank)
+{
+    TypeParam wt;
+    ASSERT_TRUE(load_from_file(wt, temp_file));
+
+    ASSERT_EQ(text.size(), wt.size());
+
+    // Test rank(i, c) for each character c and position i
+    unsigned cnt_prefix_rank[4] = {0};
+    for (unsigned i = 0; i < text.size() + 1; ++i)
+    {
+        for (unsigned v = 0; v < wt.sigma; ++v)
+        {
+            if (i > 0 && text[i - 1] <= v)
+                ++cnt_prefix_rank[v];
+
+            // auto const rank = rb(i, v);
+            if (v > 0)
+                ASSERT_EQ(cnt_prefix_rank[v] - cnt_prefix_rank[v - 1], wt.rank(i, v))<<" v="<<v;
+            else
+                ASSERT_EQ(cnt_prefix_rank[v], wt.rank(i, v))<<" v="<<v;
+
+            if (v > 0)
+            {
+                auto lex = wt.lex_smaller_count(i, v);
+                ASSERT_EQ(cnt_prefix_rank[v - 1], std::get<1>(lex))<<" v="<<v;
+            }
+        }
+    }
+}
+
+#if SDSL_HAS_CEREAL
+template <typename in_archive_t, typename out_archive_t, typename TypeParam>
+void do_serialisation(TypeParam const & l)
+{
+	{
+		std::ofstream os{temp_file, std::ios::binary};
+		out_archive_t oarchive{os};
+		oarchive(l);
+	}
+
+	{
+		TypeParam in_l{};
+		std::ifstream is{temp_file, std::ios::binary};
+		in_archive_t iarchive{is};
+		iarchive(in_l);
+		EXPECT_EQ(l, in_l);
+	}
+}
+
+TYPED_TEST(wt_byte_epr_test, cereal)
+{
+	if (temp_dir != "@/")
+	{
+		TypeParam wt;
+	        ASSERT_TRUE(load_from_file(wt, temp_file));
+
+		do_serialisation<cereal::BinaryInputArchive,         cereal::BinaryOutputArchive>        (wt);
+		do_serialisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(wt);
+		do_serialisation<cereal::JSONInputArchive,           cereal::JSONOutputArchive>          (wt);
+		do_serialisation<cereal::XMLInputArchive,            cereal::XMLOutputArchive>           (wt);
+	}
+}
+#endif // SDSL_HAS_CEREAL
+
+TYPED_TEST(wt_byte_epr_test, delete_)
+{
+    sdsl::remove(temp_file);
+}
+
+}  // namespace
+
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    if (argc < 2) {
+        // LCOV_EXCL_START
+        std::cout << "Usage: " << argv[0] << " tmp_dir" << std::endl;
+        return 1;
+        // LCOV_EXCL_STOP
+    }
+    temp_dir = argv[1];
+    temp_file = temp_dir + "/wt_epr";
+
+    auto const seed{time(NULL)};
+    srand(seed);
+
+    return RUN_ALL_TESTS();
+}

--- a/test/wt_byte_epr_test.cpp
+++ b/test/wt_byte_epr_test.cpp
@@ -1,10 +1,13 @@
-#include "sdsl/wavelet_trees.hpp"
-#include "common.hpp"
-#include "gtest/gtest.h"
-#include <vector>
-#include <string>
 #include <algorithm> // for std::min
 #include <random>
+#include <string>
+#include <vector>
+
+#include <sdsl/wavelet_trees.hpp>
+
+#include "common.hpp"
+
+#include <gtest/gtest.h>
 
 namespace
 {
@@ -18,14 +21,13 @@ string temp_file;
 string temp_dir;
 int_vector<8> text;
 
-template<class T>
-class wt_byte_epr_test : public ::testing::Test { };
+template <class T>
+class wt_byte_epr_test : public ::testing::Test
+{};
 
 using testing::Types;
 
-typedef Types<
-    wt_epr<4>
-> Implementations;
+typedef Types<wt_epr<4>> Implementations;
 
 TYPED_TEST_CASE(wt_byte_epr_test, Implementations);
 
@@ -53,8 +55,10 @@ TYPED_TEST(wt_byte_epr_test, sigma)
     ASSERT_EQ(text.size(), wt.size());
     bit_vector occur(256, 0);
     uint16_t sigma = 0;
-    for (size_type j=0; j<text.size(); ++j) {
-        if (!occur[(unsigned char)text[j]]) {
+    for (size_type j = 0; j < text.size(); ++j)
+    {
+        if (!occur[(unsigned char)text[j]])
+        {
             occur[(unsigned char)text[j]] = 1;
             ++sigma;
         }
@@ -62,13 +66,11 @@ TYPED_TEST(wt_byte_epr_test, sigma)
     ASSERT_EQ(sigma, wt.sigma);
 }
 
-template<class t_wt>
-void compare_wt(const int_vector<8>& text, const t_wt& wt)
+template <class t_wt>
+void compare_wt(const int_vector<8> & text, const t_wt & wt)
 {
     ASSERT_EQ(text.size(), wt.size());
-    for (size_type j=0; j<text.size(); ++j) {
-        ASSERT_EQ((typename t_wt::value_type)text[j], wt[j])<<" j="<<j;
-    }
+    for (size_type j = 0; j < text.size(); ++j) { ASSERT_EQ((typename t_wt::value_type)text[j], wt[j]) << " j=" << j; }
 }
 
 //! Test Access method, Copy-construtor, Move-constructor, Copy-assign and Move-assign
@@ -106,24 +108,23 @@ TYPED_TEST(wt_byte_epr_test, rank)
     ASSERT_EQ(text.size(), wt.size());
 
     // Test rank(i, c) for each character c and position i
-    unsigned cnt_prefix_rank[4] = {0};
+    unsigned cnt_prefix_rank[4] = { 0 };
     for (unsigned i = 0; i < text.size() + 1; ++i)
     {
         for (unsigned v = 0; v < wt.sigma; ++v)
         {
-            if (i > 0 && text[i - 1] <= v)
-                ++cnt_prefix_rank[v];
+            if (i > 0 && text[i - 1] <= v) ++cnt_prefix_rank[v];
 
             // auto const rank = rb(i, v);
             if (v > 0)
-                ASSERT_EQ(cnt_prefix_rank[v] - cnt_prefix_rank[v - 1], wt.rank(i, v))<<" v="<<v;
+                ASSERT_EQ(cnt_prefix_rank[v] - cnt_prefix_rank[v - 1], wt.rank(i, v)) << " v=" << v;
             else
-                ASSERT_EQ(cnt_prefix_rank[v], wt.rank(i, v))<<" v="<<v;
+                ASSERT_EQ(cnt_prefix_rank[v], wt.rank(i, v)) << " v=" << v;
 
             if (v > 0)
             {
                 auto lex = wt.lex_smaller_count(i, v);
-                ASSERT_EQ(cnt_prefix_rank[v - 1], std::get<1>(lex))<<" v="<<v;
+                ASSERT_EQ(cnt_prefix_rank[v - 1], std::get<1>(lex)) << " v=" << v;
             }
         }
     }
@@ -133,33 +134,33 @@ TYPED_TEST(wt_byte_epr_test, rank)
 template <typename in_archive_t, typename out_archive_t, typename TypeParam>
 void do_serialisation(TypeParam const & l)
 {
-	{
-		std::ofstream os{temp_file, std::ios::binary};
-		out_archive_t oarchive{os};
-		oarchive(l);
-	}
+    {
+        std::ofstream os{ temp_file, std::ios::binary };
+        out_archive_t oarchive{ os };
+        oarchive(l);
+    }
 
-	{
-		TypeParam in_l{};
-		std::ifstream is{temp_file, std::ios::binary};
-		in_archive_t iarchive{is};
-		iarchive(in_l);
-		EXPECT_EQ(l, in_l);
-	}
+    {
+        TypeParam in_l{};
+        std::ifstream is{ temp_file, std::ios::binary };
+        in_archive_t iarchive{ is };
+        iarchive(in_l);
+        EXPECT_EQ(l, in_l);
+    }
 }
 
 TYPED_TEST(wt_byte_epr_test, cereal)
 {
-	if (temp_dir != "@/")
-	{
-		TypeParam wt;
-	        ASSERT_TRUE(load_from_file(wt, temp_file));
+    if (temp_dir != "@/")
+    {
+        TypeParam wt;
+        ASSERT_TRUE(load_from_file(wt, temp_file));
 
-		do_serialisation<cereal::BinaryInputArchive,         cereal::BinaryOutputArchive>        (wt);
-		do_serialisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(wt);
-		do_serialisation<cereal::JSONInputArchive,           cereal::JSONOutputArchive>          (wt);
-		do_serialisation<cereal::XMLInputArchive,            cereal::XMLOutputArchive>           (wt);
-	}
+        do_serialisation<cereal::BinaryInputArchive, cereal::BinaryOutputArchive>(wt);
+        do_serialisation<cereal::PortableBinaryInputArchive, cereal::PortableBinaryOutputArchive>(wt);
+        do_serialisation<cereal::JSONInputArchive, cereal::JSONOutputArchive>(wt);
+        do_serialisation<cereal::XMLInputArchive, cereal::XMLOutputArchive>(wt);
+    }
 }
 #endif // SDSL_HAS_CEREAL
 
@@ -168,12 +169,13 @@ TYPED_TEST(wt_byte_epr_test, delete_)
     sdsl::remove(temp_file);
 }
 
-}  // namespace
+} // namespace
 
-int main(int argc, char** argv)
+int main(int argc, char ** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);
-    if (argc < 2) {
+    if (argc < 2)
+    {
         // LCOV_EXCL_START
         std::cout << "Usage: " << argv[0] << " tmp_dir" << std::endl;
         return 1;
@@ -182,7 +184,7 @@ int main(int argc, char** argv)
     temp_dir = argv[1];
     temp_file = temp_dir + "/wt_epr";
 
-    auto const seed{time(NULL)};
+    auto const seed{ time(NULL) };
     srand(seed);
 
     return RUN_ALL_TESTS();


### PR DESCRIPTION
Finalises and improves the original PR for the EPR dictionary.
Supersedes #70 
resolves https://github.com/seqan/product_backlog/issues/21

This is a more efficient re-implementation of the rank_support_int_v which is roughly 20% faster than SeqAn2

```console
Run on (8 X 2600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
Load Average: 2.72, 2.72, 2.78
---------------------------------------------------------------------------
Benchmark                                 Time             CPU   Iterations
---------------------------------------------------------------------------
rank<seqan::Dna>/100                    36.9 ns         36.7 ns     18915954
rank<seqan::Dna>/10000                  39.2 ns         38.8 ns     18693086
rank<seqan::Dna>/1000000                38.2 ns         38.0 ns     18565079
rank<seqan::Dna>/100000000              96.3 ns         96.0 ns      7416747
rank<seqan::Dna>/1000000000              118 ns          117 ns      5913111
rank<seqan::AminoAcid>/100              33.6 ns         33.5 ns     20678980
rank<seqan::AminoAcid>/10000            33.3 ns         33.2 ns     20833581
rank<seqan::AminoAcid>/1000000          80.8 ns         80.5 ns      8452371
rank<seqan::AminoAcid>/100000000         171 ns          170 ns      4500421
rank<seqan::AminoAcid>/1000000000        224 ns          222 ns      3202225
```
 And the new epr rank (using interleaved superblocks):

```console
Run on (8 X 2600 MHz CPU s)
CPU Caches:
  L1 Data 32K (x4)
  L1 Instruction 32K (x4)
  L2 Unified 262K (x4)
  L3 Unified 6291K (x1)
Load Average: 3.51, 2.90, 2.72
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
rank<4>/100               28.5 ns         28.3 ns     24970214
rank<4>/10000             28.2 ns         28.1 ns     24002853
rank<4>/1000000           28.8 ns         28.7 ns     24594369
rank<4>/100000000         73.5 ns         73.2 ns      9967818
rank<4>/1000000000        87.3 ns         87.1 ns      8899059
rank<27>/100              26.0 ns         25.9 ns     27164528
rank<27>/10000            27.1 ns         26.9 ns     26758205
rank<27>/1000000          60.9 ns         60.7 ns     11156445
rank<27>/100000000         113 ns          113 ns      6447750
rank<27>/1000000000        183 ns          181 ns      3406459
```

Old SDSL epr branch (using aligned int_vector with wasting bits):

```cpp
--------------------------------------------------------------
Benchmark                    Time             CPU   Iterations
--------------------------------------------------------------
rank<4>/100               28.2 ns         28.0 ns     22793433
rank<4>/10000             27.8 ns         27.7 ns     24657611
rank<4>/1000000           30.9 ns         30.3 ns     22921885
rank<4>/100000000          110 ns          109 ns      6638280
rank<4>/1000000000         142 ns          141 ns      4901103
rank<27>/100              26.3 ns         26.1 ns     25351021
rank<27>/10000            27.3 ns         27.1 ns     26736436
rank<27>/1000000          59.7 ns         59.4 ns      9280866
rank<27>/100000000         178 ns          177 ns      4100545
rank<27>/1000000000        234 ns          230 ns      2543253
```