### PR TITLE
Include system headers first, include cinttypes

### DIFF
--- a/include/sdsl/int_vector.hpp
+++ b/include/sdsl/int_vector.hpp
@@ -9,6 +9,7 @@
 #define INCLUDED_SDSL_INT_VECTOR
 
 #include <cassert>
+#include <cinttypes>
 #include <cstddef>
 #include <cstdlib>
 #include <cstring> // for memcpy

--- a/include/sdsl/int_vector_mapper.hpp
+++ b/include/sdsl/int_vector_mapper.hpp
@@ -5,7 +5,7 @@
 #define SDSL_INT_VECTOR_MAPPER
 
 #include <cstdio>
-#include <inttypes.h>
+#include <cinttypes>
 #include <ios>
 
 #include <sdsl/int_vector.hpp>


### PR DESCRIPTION
When using SDSL as part of a custom tool and building it with conda-build, I got an error about the use of PRIu64. It turned out that the compiler used by conda-build comes with a version of inttypes.h with content similar to the following:

    #if !defined __cplusplus || defined __STDC_FORMAT_MACROS
    // …
    // PRIu64 etc. defined

__STDC_FORMAT_MACROS is defined in cinttypes but if inttypes.h is included first, PRIu64 etc. will not get defined. To solve the issue, I moved system headers first in files that might be affected by the issue.