### PR TITLE
Fix select_support_mcl::init_fast

### DIFF
--- a/include/sdsl/select_support_mcl.hpp
+++ b/include/sdsl/select_support_mcl.hpp
@@ -243,7 +243,6 @@ void select_support_mcl<t_b, t_pat_len>::init_slow(const bit_vector* v)
 	}
 }
 
-// TODO: find bug, detected by valgrind
 template <uint8_t t_b, uint8_t t_pat_len>
 void select_support_mcl<t_b, t_pat_len>::init_fast(const bit_vector* v)
 {
@@ -272,6 +271,7 @@ void select_support_mcl<t_b, t_pat_len>::init_fast(const bit_vector* v)
 	for (size_type i = 0, cnt_old = 0, cnt_new = 0, last_k64_sum = 1; i < (((v->bit_size() + 63) >> 6) << 6);
 		 i += 64, ++data) {
 		cnt_new += select_support_trait<t_b, t_pat_len>::args_in_the_word(*data, carry_new);
+		cnt_new = std::min(cnt_new, m_arg_cnt); // For (0, 1), we may find nonexistent args in the padding after the bitvector.
 		if (cnt_new >= last_k64_sum) {
 			arg_position[last_k64 - 1] =
 			i + select_support_trait<t_b, t_pat_len>::ith_arg_pos_in_the_word(


### PR DESCRIPTION
Now that this development version is active again, here is one fix from the [vgteam fork](https://github.com/vgteam/sdsl-lite) of the old SDSL.

`select_support_mcl::init_fast` would sometimes crash because the initialization tries to access the padding after the bitvector (see simongog#402). This PR fixes the issue.

In the example, `pos_of_last_arg_in_the_block` is 25587424, which is greater than the length of the bitvector (25587416).

The relevant part of the code is here: https://github.com/xxsds/sdsl-lite/blob/master/include/sdsl/select_support_mcl.hpp#L274-L303

* On line 274, `args_in_the_word()` may find nonexistent args in the padding, at least for `select_support_mcl<0, 1>`.
* That could bring the number of args in the last superblock past another multiple of 64, passing the test on line 275.
* In that case, we store the position of a nonexistent arg in array `arg_position` on line 276.
* If the next multiple of 64 would start another superblock, we have a full superblock and pass the test on line 282.
* On line 284, we take the the nonexistent position we stored in `arg_position` as a candidate for `pos_of_last_arg_in_the_block`.
* We don't find further candidates, because the loop on line 286 tests for `ii < v->size()`.
* If the last superblock happens to be long, we pass the test on line 294.
* The loop on line 300 iterates over the superblock, up to and including `pos_of_last_arg_in_the_block`.
* We access each position in the superblock on line 303, which ultimately causes the assertion failure.

We can fix this by adding `cnt_new = std::min(cnt_new, m_arg_cnt);` after line 274.