### PR TITLE
[MISC] Use std::for_each to set bits in int_vector

### DIFF
--- a/include/sdsl/util.hpp
+++ b/include/sdsl/util.hpp
@@ -533,23 +533,19 @@ void util::expand_width(t_int_vec & v, uint8_t new_width)
 template <class t_int_vec>
 void util::_set_zero_bits(t_int_vec & v)
 {
-    uint64_t * data = v.data();
-    if (v.empty()) return;
-    // TODO: replace by memset() but take care of size_t in the argument!
-    *data = 0ULL;
-    for (typename t_int_vec::size_type i = 1; i < ((v.bit_size() + 63) >> 6); ++i) { *(++data) = 0ULL; }
+    std::for_each(v.data(), v.data() + ((v.bit_size() + 63) >> 6), [] (uint64_t & value)
+    {
+        value = 0ULL;
+    });
 }
 
 template <class t_int_vec>
 void util::_set_one_bits(t_int_vec & v)
 {
-    uint64_t * data = v.data();
-    if (v.empty()) return;
-    *data = 0xFFFFFFFFFFFFFFFFULL;
-    for (typename t_int_vec::size_type i = 1; i < ((v.bit_size() + 63) >> 6); ++i)
+    std::for_each(v.data(), v.data() + ((v.bit_size() + 63) >> 6), [] (uint64_t & value)
     {
-        *(++data) = 0xFFFFFFFFFFFFFFFFULL;
-    }
+        value = -1ULL;
+    });
 }
 
 inline void util::cyclic_shifts(uint64_t * vec, uint8_t & n, uint64_t k, uint8_t int_width)


### PR DESCRIPTION
https://gist.github.com/eseiler/21023865b43b6567a39fe250cf43c027

```
-----------------------------------------------------------------------
Benchmark                             Time             CPU   Iterations
-----------------------------------------------------------------------
set_to_zero_via_fill<1>          843988 ns       843992 ns          862
set_to_zero_via_fill<8>           10873 ns        10873 ns        63608
set_to_zero_via_fill<16>          23218 ns        23218 ns        30586
set_to_zero_via_fill<32>          47259 ns        47259 ns        14821
set_to_zero_via_fill<64>         102496 ns       102495 ns         6765

set_to_zero_via_memset<1>           991 ns          991 ns       705064
set_to_zero_via_memset<8>         10925 ns        10925 ns        62319
set_to_zero_via_memset<16>        23089 ns        23089 ns        30151
set_to_zero_via_memset<32>        47177 ns        47177 ns        14731
set_to_zero_via_memset<64>       100776 ns       100776 ns         6761

set_to_zero_via_for_each<1>         976 ns          976 ns       720655
set_to_zero_via_for_each<8>       11068 ns        11068 ns        64480
set_to_zero_via_for_each<16>      22932 ns        22932 ns        30491
set_to_zero_via_for_each<32>      47497 ns        47497 ns        14898
set_to_zero_via_for_each<64>     100895 ns       100895 ns         6892

set_to_zero_via_util<1>            5533 ns         5533 ns       120266
set_to_zero_via_util<8>           44126 ns        44126 ns        15609
set_to_zero_via_util<16>          88631 ns        88632 ns         7878
set_to_zero_via_util<32>         177313 ns       177313 ns         3958
set_to_zero_via_util<64>         355713 ns       355713 ns         1974

set_to_zero_via_assign<1>          5498 ns         5498 ns       125323
set_to_zero_via_assign<8>         44371 ns        44371 ns        15873
set_to_zero_via_assign<16>        93043 ns        93043 ns         7340
set_to_zero_via_assign<32>       179523 ns       179523 ns         3572
set_to_zero_via_assign<64>       507330 ns       507331 ns         1373
```

(Equivalent results for `set_to_one`)