### PR TITLE
Conditionally use std::invoke_result_t

### DIFF
--- a/include/sdsl/iterators.hpp
+++ b/include/sdsl/iterators.hpp
@@ -9,7 +9,7 @@
 #define INCLUDED_SDSL_ITERATORS
 
 #include <iterator>
-#include <type_traits> // __cpp_lib_is_invocable
+#include <type_traits> // std::invoke_result_t
 
 #include <sdsl/int_vector.hpp>
 
@@ -140,11 +140,7 @@ struct random_access_container
 {
     typedef int_vector<>::size_type size_type;
     typedef int_vector<>::difference_type difference_type;
-#ifdef __cpp_lib_is_invocable
     typedef typename std::invoke_result_t<t_F, size_type> value_type;
-#else
-    typedef typename std::result_of<t_F(size_type)>::type value_type;
-#endif
     typedef random_access_const_iterator<random_access_container> iterator_type;
 
     t_F f;


### PR DESCRIPTION
- std::result_of has been deprecated in C++17 and removed in C++20.