### PR TITLE
Detecting PPC64/ARM64 CPUs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 Other compiler may work, but are not tested within the continuous integration. In general, the latest minor release of each
 listed major compiler version is supported.
 
-* GCC 10, 11, 12
+* GCC 10, 11, 12, 13
 * clang 11, 12, 13, 14
 
 Tests are run with both C++20 and C++23.

--- a/include/sdsl/bits.hpp
+++ b/include/sdsl/bits.hpp
@@ -8,7 +8,7 @@
 #ifndef INCLUDED_SDSL_BITS
 #define INCLUDED_SDSL_BITS
 
-# GCC definitions
+// GCC definitions
 #if defined(__x86_64__)
 #include <immintrin.h> // IWYU pragma: keep
 #endif

--- a/include/sdsl/bits.hpp
+++ b/include/sdsl/bits.hpp
@@ -8,7 +8,17 @@
 #ifndef INCLUDED_SDSL_BITS
 #define INCLUDED_SDSL_BITS
 
+# GCC definitions
+#if defined(__x86_64__)
 #include <immintrin.h> // IWYU pragma: keep
+#endif
+#if defined(__aarch64__) || defined(_M_ARM64)
+#include <arm_neon.h>
+#endif
+#if defined(__powerpc__) || defined(__powerpc64__)
+#include <altivec.h>
+#endif
+
 #include <stddef.h>
 #include <stdint.h> // for uint64_t uint32_t declaration
 #ifdef __SSE4_2__


### PR DESCRIPTION
Hi all.

This change has made for compiling on `ARM64` and `PPC64` architectures with `GCC-13` for Fedora 39.
The builds and related logs for testing are [here](https://koji.fedoraproject.org/koji/taskinfo?taskID=103559770)