### PR TITLE
Use pointer to the container for int_vector_buffer iterator

### DIFF
--- a/include/sdsl/int_vector_buffer.hpp
+++ b/include/sdsl/int_vector_buffer.hpp
@@ -494,7 +494,7 @@ public:
     class iterator
     {
     private:
-        int_vector_buffer<t_width> * m_ivb;
+        int_vector_buffer<t_width> * m_ivb{nullptr};
         uint64_t m_idx = 0;
 
     public:
@@ -536,6 +536,7 @@ public:
 
         reference operator*() const
         {
+            assert(m_ivb != nullptr);
             return (*m_ivb)[m_idx];
         }
 

--- a/include/sdsl/int_vector_buffer.hpp
+++ b/include/sdsl/int_vector_buffer.hpp
@@ -30,6 +30,7 @@ public:
 
     typedef typename int_vector<t_width>::difference_type difference_type;
     typedef typename int_vector<t_width>::value_type value_type;
+    typedef typename int_vector<t_width>::size_type size_type;
 
 private:
     static_assert(t_width <= 64, "int_vector_buffer: width must be at most 64 bits.");
@@ -493,7 +494,7 @@ public:
     class iterator
     {
     private:
-        int_vector_buffer<t_width> & m_ivb;
+        int_vector_buffer<t_width> * m_ivb;
         uint64_t m_idx = 0;
 
     public:
@@ -504,7 +505,7 @@ public:
         using reference = sdsl::int_vector_buffer<t_width>::reference;
 
         iterator() = delete;
-        iterator(int_vector_buffer<t_width> & ivb, uint64_t idx = 0) : m_ivb(ivb), m_idx(idx)
+        iterator(int_vector_buffer<t_width> & ivb, uint64_t idx = 0) : m_ivb(&ivb), m_idx(idx)
         {}
 
         iterator & operator++()
@@ -535,7 +536,7 @@ public:
 
         reference operator*() const
         {
-            return m_ivb[m_idx];
+            return (*m_ivb)[m_idx];
         }
 
         iterator & operator+=(difference_type i)
@@ -568,7 +569,7 @@ public:
 
         bool operator==(iterator const & it) const
         {
-            return &m_ivb == &(it.m_ivb) and m_idx == it.m_idx;
+            return m_ivb == it.m_ivb and m_idx == it.m_idx;
         }
 
         bool operator!=(iterator const & it) const


### PR DESCRIPTION
Using reference member prevents defining assignment operator for the iterator class of `int_vector_buffer`. This commit fixes issue simongog/sdsl-lite#436 (the same [PR](https://github.com/simongog/sdsl-lite/pull/437) is still open in Simon's fork but it is merged in vgteam's fork).

On a completely different note, I noticed that the assign interface functions (in `utils.hpp`) are removed (I mean [these functions](https://github.com/cartoonist/sdsl-lite/commit/e9156a894bada102c14f941cb43ac1d8fa04c3b4)). Is there any specific reason why they are removed?