### PR TITLE
Fix/epr dictionaries

### DIFF
--- a/include/sdsl/wt_epr.hpp
+++ b/include/sdsl/wt_epr.hpp
@@ -119,13 +119,10 @@ public:
             return;
 
         // The largest letter, is the effective alphabet size
-        for (auto it = begin; it != end; ++it)
+        if (std::any_of(begin, end, [](size_t value) { return value >= alphabet_size; }))
         {
-            size_t c = *it;
-            // The text cannot have a character equal or larger than the required alphabet_size.
-            if (c >= alphabet_size)
-                throw std::domain_error{"The given text uses an alphabet that is larger than the explicitly given "
-                                        "alphabet size."};
+            throw std::domain_error{"The given text uses an alphabet that is larger than the explicitly given "
+                                    "alphabet size."};
         }
         m_sigma = alphabet_size;
 

--- a/include/sdsl/wt_epr.hpp
+++ b/include/sdsl/wt_epr.hpp
@@ -106,7 +106,7 @@ public:
     //!\brief Default constructor.
     wt_epr() = default;
 
-    /*!\brief Construct the EPR-dictionary from a sequence defined by two interators
+    /*!\brief Construct the EPR-dictionary from a sequence defined by two iterators
      * \param begin Iterator to the start of the input.
      * \param end   Iterator one past the end of the input.
      * \par Time complexity
@@ -117,22 +117,19 @@ public:
     {
         if (0 == m_size)
             return;
-        // O(n + |\Sigma|\log|\Sigma|) algorithm for calculating node sizes
-        // TODO: C should also depend on the tree_strategy. C is just a mapping
-        // from a symbol to its frequency. So a map<uint64_t,uint64_t> could be
-        // used for integer alphabets...
-        std::vector<size_type> C;
-        // 1. Count occurrences of characters
-        calculate_character_occurences(begin, end, C);
-        // 2. Calculate effective alphabet size
-        calculate_effective_alphabet_size(C, m_sigma);
 
-        // The text cannot have an alphabet larger than the required alphabet_size.
-        if (m_sigma > alphabet_size)
-            throw std::domain_error{"The given text uses an alphabet that is larger than the explicitly given "
-                                    "alphabet size."};
+        // The largest letter, is the effective alphabet size
+        for (auto it = begin; it != end; ++it)
+        {
+            size_t c = *it;
+            // The text cannot have a character equal or larger than the required alphabet_size.
+            if (c >= alphabet_size)
+                throw std::domain_error{"The given text uses an alphabet that is larger than the explicitly given "
+                                        "alphabet size."};
+        }
+        m_sigma = alphabet_size;
 
-        // 4. Generate wavelet tree bit sequence m_bv
+        // Generate wavelet tree bit sequence m_bv
         int_vector<> intermediate_bitvector{};
         intermediate_bitvector.width(std::ceil(std::log2(m_sigma)));
         intermediate_bitvector.resize(m_size);

--- a/test/wt_byte_epr_test.cpp
+++ b/test/wt_byte_epr_test.cpp
@@ -36,7 +36,7 @@ int_vector<8> wt_byte_epr_test<T>::text{[]()
                                             result.resize(std::rand() % 10000);
                                             for (uint32_t i = 0; i < result.size(); ++i)
                                             {
-                                                result[i] = (std::rand() % 3) + 1; // no 0s allowed. produces 1, 2 or 3.
+                                                result[i] = std::rand() % 4;
                                             }
                                             return result;
                                         }()};


### PR DESCRIPTION
the EPR dictionaries compute an effective alphabet size, but did not use it to map characters of the text to the narrowed range. This lead to a bugs, if enough characters where missing, such that less bits where used for storage than required.


This fixes the issues, by removing the effective alphabet size, and fixing it to the requested alphabet size via template argument.

We added a test case, which triggers the error. We added a fix that fixes the error.
Additionally, I made a little fix, to one of the other unittest, testing the full range (no reason to leave out the zero).