### PR TITLE
Fix/int vector buffer random access properties

### DIFF
--- a/include/sdsl/int_vector_buffer.hpp
+++ b/include/sdsl/int_vector_buffer.hpp
@@ -577,6 +577,27 @@ public:
         {
             return !(*this == it);
         }
+
+        bool operator<(iterator const & it) const
+        {
+            return m_idx < it.m_idx;
+        }
+
+        bool operator>(iterator const & it) const
+        {
+            return m_idx > it.m_idx;
+        }
+
+        bool operator<=(iterator const & it) const
+        {
+            return m_idx <= it.m_idx;
+        }
+
+        bool operator>=(iterator const & it) const
+        {
+            return m_idx >= it.m_idx;
+        }
+
         inline difference_type operator-(iterator const & it)
         {
             return (m_idx - it.m_idx);

--- a/include/sdsl/int_vector_buffer.hpp
+++ b/include/sdsl/int_vector_buffer.hpp
@@ -570,7 +570,11 @@ public:
 
         bool operator==(iterator const & it) const
         {
-            return m_ivb == it.m_ivb and m_idx == it.m_idx;
+            // assert that iterator point to the same int_vector_buffer
+            assert(m_ivb);
+            assert(it.m_ivb);
+            assert(m_ivb == it.m_ivb);
+            return m_idx == it.m_idx;
         }
 
         bool operator!=(iterator const & it) const
@@ -580,26 +584,46 @@ public:
 
         bool operator<(iterator const & it) const
         {
+            // assert that iterator point to the same int_vector_buffer
+            assert(m_ivb);
+            assert(it.m_ivb);
+            assert(m_ivb == it.m_ivb);
             return m_idx < it.m_idx;
         }
 
         bool operator>(iterator const & it) const
         {
+            // assert that iterator point to the same int_vector_buffer
+            assert(m_ivb);
+            assert(it.m_ivb);
+            assert(m_ivb == it.m_ivb);
             return m_idx > it.m_idx;
         }
 
         bool operator<=(iterator const & it) const
         {
+            // assert that iterator point to the same int_vector_buffer
+            assert(m_ivb);
+            assert(it.m_ivb);
+            assert(m_ivb == it.m_ivb);
             return m_idx <= it.m_idx;
         }
 
         bool operator>=(iterator const & it) const
         {
+            // assert that iterator point to the same int_vector_buffer
+            assert(m_ivb);
+            assert(it.m_ivb);
+            assert(m_ivb == it.m_ivb);
             return m_idx >= it.m_idx;
         }
 
         difference_type operator-(iterator const & it) const
         {
+            // assert that iterator point to the same int_vector_buffer
+            assert(m_ivb);
+            assert(it.m_ivb);
+            assert(m_ivb == it.m_ivb);
             return (m_idx - it.m_idx);
         }
     };

--- a/include/sdsl/int_vector_buffer.hpp
+++ b/include/sdsl/int_vector_buffer.hpp
@@ -598,7 +598,7 @@ public:
             return m_idx >= it.m_idx;
         }
 
-        inline difference_type operator-(iterator const & it)
+        difference_type operator-(iterator const & it) const
         {
             return (m_idx - it.m_idx);
         }


### PR DESCRIPTION
Fixes a categorization bug of an iterator.
`int_vector_buffer::iterator` announces its `iterator_category` as `std::random_access_iterator_tag`. This requires
to support expression like `<, >, <=, >=`.
This Bug is only triggered if additionally the `_GLIBCXX_DEBUG` flag is set.

I have a "minimal example" prepared, adjust line '82' to see my fix and/or see the compiler flags to remove the trigger : https://godbolt.org/z/W65szx7Pz

(also I fixed another minor const correctness bug in a second commit)

